### PR TITLE
50% improvement on build_newick

### DIFF
--- a/phylo2vec/src/tree_vec/ops/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/mod.rs
@@ -3,7 +3,10 @@ pub mod matrix;
 pub mod newick;
 pub mod vector;
 
-use crate::{tree_vec::types::Ancestry, utils::check_m};
+use crate::{
+    tree_vec::types::{Ancestry, Pairs},
+    utils::check_m,
+};
 use matrix::parse_matrix;
 use newick::build_newick_with_bls;
 
@@ -16,8 +19,8 @@ pub use newick::{build_newick, get_cherries, get_cherries_no_parents, has_parent
 
 /// Recover a rooted tree (in Newick format) from a Phylo2Vec vector
 pub fn to_newick_from_vector(v: &[usize]) -> String {
-    let ancestry: Ancestry = get_ancestry(v);
-    build_newick(&ancestry)
+    let pairs: Pairs = get_pairs(v);
+    build_newick(&pairs)
 }
 
 /// Recover a rooted tree (in Newick format) from a Phylo2Vec matrix
@@ -26,8 +29,8 @@ pub fn to_newick_from_matrix(m: &[Vec<f32>]) -> String {
     check_m(m);
 
     let (v, bls) = parse_matrix(m);
-    let ancestry = get_ancestry(&v);
-    build_newick_with_bls(&ancestry, &bls)
+    let pairs = get_pairs(&v);
+    build_newick_with_bls(&pairs, &bls)
 }
 
 /// Recover a Phylo2Vec vector from a rooted tree (in Newick format)
@@ -158,17 +161,17 @@ mod tests {
     #[rstest]
     #[case(vec![
         vec![0.0, 0.9, 0.4],
-        vec![0.0, 0.8, 3.0],
+        vec![0.0, 0.8, 3.12],
         vec![3.0, 0.4, 0.5],
-    ], "(((0:0.9,2:0.4)4:0.8,3:3.0)5:0.4,1:0.5)6;")]
+    ], "(((0:0.9,2:0.4)4:0.8,3:3.12)5:0.4,1:0.5)6;")]
     #[case(vec![
         vec![0.0, 0.1, 0.2],
     ], "(0:0.1,1:0.2)2;")]
     #[case(vec![
-        vec![0.0, 0.0, 0.0],
+        vec![0.0, 1.0, 3.0],
         vec![0.0, 0.1, 0.2],
         vec![1.0, 0.5, 0.7],
-    ], "((0:0.1,2:0.2)5:0.5,(1:0.0,3:0.0)4:0.7)6;")]
+    ], "((0:0.1,2:0.2)5:0.5,(1:1,3:3)4:0.7)6;")]
     fn test_to_newick_from_matrix(#[case] m: Vec<Vec<f32>>, #[case] expected: &str) {
         let newick = to_newick_from_matrix(&m);
         assert_eq!(newick, expected);

--- a/py-phylo2vec/phylo2vec/base/to_newick.py
+++ b/py-phylo2vec/phylo2vec/base/to_newick.py
@@ -1,9 +1,11 @@
 """
 Methods to convert a Phylo2Vec vector to a Newick-format string.
 """
+
 import numpy as np
 
 from phylo2vec import _phylo2vec_core
+
 
 def _get_ancestry(v: np.ndarray) -> np.ndarray:
     """
@@ -40,30 +42,6 @@ def _get_ancestry(v: np.ndarray) -> np.ndarray:
     """
     ancestry_list = _phylo2vec_core.get_ancestry(v)
     return np.asarray(ancestry_list)
-
-
-def _build_newick(ancestry: np.ndarray) -> str:
-    """Build a Newick string from an "ancestry" array
-
-    The input should always be 3-dimensional with the following format:
-    1st column: child 1
-    2nd column: child 2
-    3rd column: parent node
-
-    The matrix is processed such that we iteratively write a Newick string
-    to describe the tree.
-
-    Parameters
-    ----------
-    ancestry : numpy.ndarray
-        "Ancestry" array of size (n_leaves - 1, 3)
-
-    Returns
-    -------
-    newick : str
-        Newick string
-    """
-    return _phylo2vec_core.build_newick(ancestry)
 
 
 def to_newick(v):

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -39,8 +39,8 @@ fn from_ancestry(input_ancestry: Vec<[usize; 3]>) -> Vec<usize> {
 }
 
 #[pyfunction]
-fn build_newick(input_ancestry: Vec<[usize; 3]>) -> String {
-    let newick_string: String = ops::newick::build_newick(&input_ancestry);
+fn build_newick(input_pairs: Vec<(usize, usize)>) -> String {
+    let newick_string: String = ops::newick::build_newick(&input_pairs);
     newick_string
 }
 


### PR DESCRIPTION
New functions are proposed to build a Newick string from get_pairs() instead of get_ancestry(), thus eliminating an extra step. Moreover, we get rid of recursion, which incurs a higher overload for a large number of leaves.

![image](https://github.com/user-attachments/assets/62a91942-75db-41f6-9595-0635fcb1d902)
[0003_8e8e0117f2b02383612646152fb193e9042e4b09_20250501_112011.json](https://github.com/user-attachments/files/19999309/0003_8e8e0117f2b02383612646152fb193e9042e4b09_20250501_112011.json)
