### PR TITLE
fix: fix to_matrix recursion error and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "rand",
  "regex",
  "rstest",
+ "thiserror",
 ]
 
 [[package]]
@@ -881,6 +882,26 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinytemplate"

--- a/phylo2vec/Cargo.toml
+++ b/phylo2vec/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 [dependencies]
 rand = "*"
 regex = "1.11.1"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 rstest = "0.23.0"

--- a/phylo2vec/src/tree_vec/ops/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/mod.rs
@@ -38,10 +38,10 @@ pub fn to_vector(newick: &str) -> Vec<usize> {
     let mut ancestry: Ancestry;
 
     if has_parents(newick) {
-        ancestry = get_cherries(newick);
+        ancestry = get_cherries(newick).expect("failed to get cherries");
         order_cherries(&mut ancestry);
     } else {
-        ancestry = get_cherries_no_parents(newick);
+        ancestry = get_cherries_no_parents(newick).expect("failed to get cherries with no parents");
         order_cherries_no_parents(&mut ancestry);
     }
 

--- a/phylo2vec/src/tree_vec/ops/newick/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/newick/mod.rs
@@ -1,4 +1,4 @@
-use std::num::IntErrorKind;
+use thiserror;
 
 use crate::tree_vec::types::{Ancestry, Pairs};
 
@@ -6,214 +6,251 @@ mod newick_patterns;
 
 pub use newick_patterns::NewickPatterns;
 
-fn _stoi_substr(s: &str, start: usize, end: &mut usize) -> Result<usize, IntErrorKind> {
-    let s = &s[start..];
-    let mut value = 0;
-    for (i, c) in s.chars().enumerate() {
-        if let Some(digit) = c.to_digit(10) {
-            value = value * 10 + digit as usize;
-            *end = start + i + 1;
-        } else {
+#[derive(Debug, thiserror::Error)]
+pub enum NewickError {
+    // For problematic int parsing in the Newick string
+    #[error("ParseIntError: {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+    // For problematic float parsing in the Newick string
+    #[error("ParseFloatError: {0}")]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+    // For problematic stack popping in get_cherries
+    #[error("Stack underflow error encountered")]
+    StackUnderflow,
+}
+
+fn node_substr(s: &str, start: usize) -> (&str, usize) {
+    let substr: &str = &s[start..];
+    let mut end: usize = start;
+
+    // Find the next comma, closing parenthesis, or semicolon
+    for (i, c) in substr.char_indices() {
+        if c == ',' || c == ')' || c == ';' {
+            end = start + i;
             break;
         }
     }
-    if *end > start {
-        Ok(value)
-    } else {
-        Err(std::num::IntErrorKind::Empty)
-    }
+
+    let node = &s[start..end];
+
+    (node, end)
 }
 
-fn _get_cherries_inner(ancestry: &mut Ancestry, newick: &str) {
-    let mut stack = Vec::new();
-    let mut i = 0;
+pub fn get_cherries(newick: &str) -> Result<Ancestry, NewickError> {
+    if newick.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut ancestry: Ancestry = Vec::new();
+    let mut stack: Vec<usize> = Vec::new();
 
+    let newick_bytes = newick.as_bytes();
+
+    let mut i: usize = 0;
     while i < newick.len() {
-        let c = newick.as_bytes()[i] as char;
+        let c: char = newick_bytes[i] as char;
+
         if c == ')' {
             i += 1;
 
-            let c2 = stack.pop().unwrap();
-            let c1 = stack.pop().unwrap();
+            // Pop the children nodes from the stack
+            let c2: usize = stack.pop().ok_or(NewickError::StackUnderflow)?;
+            let c1: usize = stack.pop().ok_or(NewickError::StackUnderflow)?;
 
-            let mut end = 0;
-            let p = _stoi_substr(newick, i, &mut end).expect("Bad input");
+            // Get the parent node after ")"
+            let (p, end) = node_substr(newick, i);
             i = end - 1;
 
-            ancestry.push([c1, c2, p]);
-            stack.push(p);
+            let p_int = p.parse::<usize>().map_err(NewickError::ParseIntError)?;
+
+            // Add the triplet (c1, c2, p)
+            ancestry.push([c1, c2, p_int]);
+
+            // Push the parent node to the stack
+            stack.push(p_int);
         } else if c.is_ascii_digit() {
-            let mut end = 0;
-            let node = _stoi_substr(newick, i, &mut end).expect("Bad input");
-            stack.push(node);
+            // Get the next node and push it to the stack
+            let (node, end) = node_substr(newick, i);
             i = end - 1;
+
+            stack.push(node.parse::<usize>().map_err(NewickError::ParseIntError)?);
         }
+
         i += 1;
     }
+
+    Ok(ancestry)
 }
 
-fn _get_cherries_no_parents_inner(ancestry: &mut Ancestry, newick: &str) {
-    let newick_length = newick.len();
-    let mut stack = Vec::with_capacity(newick_length);
-    let mut i = 0;
+pub fn get_cherries_with_bls(newick: &str) -> Result<(Ancestry, Vec<[f32; 2]>), NewickError> {
+    if newick.is_empty() {
+        return Ok((Vec::new(), Vec::new())); // Return empty ancestry and branch length vectors
+    }
+    let mut ancestry: Ancestry = Vec::new();
+    let mut bls: Vec<[f32; 2]> = Vec::new();
+    let mut stack: Vec<usize> = Vec::new();
+    let mut bl_stack: Vec<f32> = Vec::new();
 
-    while i < newick_length {
-        let c = newick.as_bytes()[i] as char;
+    let mut i: usize = 0;
+
+    let newick_bytes = newick.as_bytes();
+
+    while i < newick.len() {
+        let c: char = newick_bytes[i] as char;
 
         if c == ')' {
-            let c2 = stack.pop().unwrap();
-            let c1 = stack.pop().unwrap();
+            i += 1;
 
-            let c_max = std::cmp::max(c1, c2);
-            ancestry.push([c1, c2, c_max]);
+            // Pop the children nodes from the stack
+            let c2: usize = stack.pop().ok_or(NewickError::StackUnderflow)?;
+            let c1: usize = stack.pop().ok_or(NewickError::StackUnderflow)?;
 
-            let c_min = std::cmp::min(c1, c2);
-            stack.push(c_min);
-        } else if c.is_ascii_digit() {
-            let mut end = 0;
-            let leaf = _stoi_substr(newick, i, &mut end).expect("Bad input");
-            stack.push(leaf);
-            i = end - 1;
-        }
-        i += 1;
-    }
-}
-
-fn _get_cherries_recursive_inner_with_bls(
-    ancestry: &mut Ancestry,
-    bls: &mut Vec<[f32; 2]>,
-    newick: &str,
-    newick_has_parents: bool,
-) {
-    let mut open_idx: usize = 0;
-
-    for (i, ch) in newick.chars().enumerate() {
-        if ch == '(' {
-            open_idx = i + 1;
-        } else if ch == ')' {
-            let parts: Vec<&str> = newick[open_idx..i].split(',').collect();
-            let part = parts[0];
-            let c1: usize;
-            let c2;
-            let mut bl1 = 0.0;
-            let mut bl2 = 0.0;
-            if part.contains(':') {
-                // have to account for base case in which newick string is just a leaf
-                let (child1_str, bl1_str) = part.split_once(':').unwrap();
-                let (child2_str, bl2_str) = parts[1].split_once(':').unwrap();
-
-                // Parse the children (c1, c2)
-                c1 = child1_str.parse::<usize>().unwrap();
-                c2 = child2_str.parse::<usize>().unwrap();
-
-                // Parse the branch lengths (bl1, bl2)
-                bl1 = bl1_str.parse::<f32>().unwrap_or(0.0);
-                bl2 = bl2_str.parse::<f32>().unwrap_or(0.0);
-            } else {
-                c1 = parts[0].parse::<usize>().unwrap();
-                c2 = parts[1].parse::<usize>().unwrap();
-            }
-
-            // The parent node (if present)
-            let parent: usize;
-            // let _blp: f32;
-            let new_newick: String;
-
-            if newick_has_parents {
-                let parent_pair = newick[i + 1..]
-                    .split(',')
-                    .next()
-                    .unwrap_or("")
-                    .split(')')
-                    .next()
-                    .unwrap_or("")
-                    .to_string();
-
-                // Attempt to split by ":" to extract the branch length if it exists
-                if parent_pair.is_empty() {
-                    continue;
-                } else {
-                    let (parent_str, blp_str) = parent_pair.split_once(':').unwrap();
-                    eprint!("parent_str: {}, blp_str: {}", parent_str, blp_str);
-                    parent = match parent_str.parse::<usize>() {
-                        Ok(parent_value) => parent_value, // Successfully parsed the parent node
-                        Err(_) => std::cmp::max(c1, c2),  // Fallback value if parsing fails
-                    };
-                }
-                new_newick = format!("{}{}", &newick[..open_idx - 1], &newick[i + 1..]);
-            }
-            // If the newick string does not have parents
-            else {
-                parent = std::cmp::max(c1, c2);
-                new_newick = newick.replace(
-                    &newick[open_idx - 1..=i],
-                    &std::cmp::min(c1, c2).to_string(),
-                );
-            }
-
-            // Append to ancestry (nodes)
-            ancestry.push([c1, c2, parent]);
-
-            // Append the branch lengths
+            // Pop the BLs from the BL stack
+            let bl2: f32 = bl_stack.pop().ok_or(NewickError::StackUnderflow)?;
+            let bl1: f32 = bl_stack.pop().ok_or(NewickError::StackUnderflow)?;
             bls.push([bl1, bl2]);
 
-            // Recursively process the next part of the newick string
-            return _get_cherries_recursive_inner_with_bls(
-                ancestry,
-                bls,
-                &new_newick,
-                newick_has_parents,
-            );
+            let (annotated_p, end) = node_substr(newick, i);
+            i = end - 1;
+
+            if end == newick.len() - 1 {
+                let p = annotated_p.split(':').next().unwrap();
+                let p_int: usize = p.parse::<usize>().map_err(NewickError::ParseIntError)?;
+                ancestry.push([c1, c2, p_int]);
+            } else {
+                // Add the triplet (c1, c2, p)
+                let (p, blp) = annotated_p.split_once(':').unwrap();
+
+                let p_int = p.parse::<usize>().map_err(NewickError::ParseIntError)?;
+
+                ancestry.push([c1, c2, p_int]);
+
+                // Push the parent node to the stack
+                stack.push(p_int);
+                // Push the parent BL to the BL stack
+                bl_stack.push(blp.parse::<f32>().map_err(NewickError::ParseFloatError)?);
+            }
+        } else if c.is_ascii_digit() {
+            let (annotated_node, end) = node_substr(newick, i);
+            i = end - 1;
+
+            let (node, bln) = annotated_node.split_once(':').unwrap();
+
+            stack.push(node.parse::<usize>().map_err(NewickError::ParseIntError)?);
+            bl_stack.push(bln.parse::<f32>().map_err(NewickError::ParseFloatError)?);
         }
+
+        i += 1;
     }
+
+    Ok((ancestry, bls))
 }
 
-pub fn get_cherries(newick: &str) -> Ancestry {
+pub fn get_cherries_no_parents(newick: &str) -> Result<Ancestry, NewickError> {
     if newick.is_empty() {
-        return Vec::new(); // Return empty ancestry and branch length vectors
+        return Ok(Vec::new());
     }
     let mut ancestry: Ancestry = Vec::new();
-    _get_cherries_inner(&mut ancestry, &newick[..newick.len() - 1]);
-    ancestry
-}
+    let mut stack: Vec<usize> = Vec::new();
 
-pub fn get_cherries_with_bls(newick: &str) -> (Ancestry, Vec<[f32; 2]>) {
+    let newick_bytes = newick.as_bytes();
+
+    let mut i: usize = 0;
+    while i < newick.len() {
+        let c: char = newick_bytes[i] as char;
+
+        if c == ')' {
+            // Pop the children nodes from the stack
+            let c2: usize = stack.pop().ok_or(NewickError::StackUnderflow)?;
+            let c1: usize = stack.pop().ok_or(NewickError::StackUnderflow)?;
+
+            let mut c_ordered = [c1, c2];
+            c_ordered.sort();
+
+            // No parent annotation --> store the max leaf
+            ancestry.push([c1, c2, c_ordered[1]]);
+
+            // Push the min leaf to the stack to represent this internal node going forward
+            stack.push(c_ordered[0]);
+        } else if c.is_ascii_digit() {
+            // Get the next leaf and push it to the stack
+            let (leaf, end) = node_substr(newick, i);
+            i = end - 1;
+
+            stack.push(leaf.parse::<usize>().map_err(NewickError::ParseIntError)?);
+        }
+
+        i += 1;
+    }
+
+    Ok(ancestry)
+}
+pub fn get_cherries_no_parents_with_bls(
+    newick: &str,
+) -> Result<(Ancestry, Vec<[f32; 2]>), NewickError> {
     if newick.is_empty() {
-        return (Vec::new(), Vec::new()); // Return empty ancestry and branch length vectors
+        return Ok((Vec::new(), Vec::new())); // Return empty ancestry and branch length vectors
     }
     let mut ancestry: Ancestry = Vec::new();
     let mut bls: Vec<[f32; 2]> = Vec::new();
-    _get_cherries_recursive_inner_with_bls(
-        &mut ancestry,
-        &mut bls,
-        &newick[..newick.len() - 1],
-        true,
-    );
-    (ancestry, bls)
-}
+    let mut stack: Vec<usize> = Vec::new();
+    let mut bl_stack: Vec<f32> = Vec::new();
 
-pub fn get_cherries_no_parents(newick: &str) -> Ancestry {
-    if newick.is_empty() {
-        return Vec::new(); // Return empty ancestry and branch length vectors
-    }
-    let mut ancestry: Ancestry = Vec::new();
-    _get_cherries_no_parents_inner(&mut ancestry, &newick[..newick.len() - 1]);
-    ancestry
-}
+    let mut i: usize = 0;
 
-pub fn get_cherries_no_parents_with_bls(newick: &str) -> (Ancestry, Vec<[f32; 2]>) {
-    if newick.is_empty() {
-        return (Vec::new(), Vec::new()); // Return empty ancestry and branch length vectors
+    let newick_bytes: &[u8] = newick.as_bytes();
+
+    while i < newick.len() {
+        let c: char = newick_bytes[i] as char;
+
+        if c == ')' {
+            i += 1;
+
+            // Pop the children nodes from the stack
+            let c2: usize = stack.pop().ok_or(NewickError::StackUnderflow)?;
+            let c1: usize = stack.pop().ok_or(NewickError::StackUnderflow)?;
+
+            // Pop the BLs from the BL stack
+            let bl2: f32 = bl_stack.pop().ok_or(NewickError::StackUnderflow)?;
+            let bl1: f32 = bl_stack.pop().ok_or(NewickError::StackUnderflow)?;
+
+            let mut c_ordered = [c1, c2];
+            c_ordered.sort();
+
+            // No parent annotation --> store the max leaf
+            ancestry.push([c1, c2, c_ordered[1]]);
+            bls.push([bl1, bl2]);
+            // Find the parental BL
+            // Ex: ":0.2"
+            let (annotated_node, end) = node_substr(newick, i);
+            i = end - 1;
+
+            if annotated_node.is_empty() && end == newick.len() - 1 {
+                // if this is true, we reached the root without a BL
+                break;
+            }
+
+            // Push the min leaf to the stack
+            stack.push(c_ordered[0]);
+            // Push the parent BL to the BL stack
+            bl_stack.push(
+                annotated_node[1..]
+                    .parse::<f32>()
+                    .map_err(NewickError::ParseFloatError)?,
+            );
+        } else if c.is_ascii_digit() {
+            let (annotated_node, end) = node_substr(newick, i);
+            i = end - 1;
+
+            let (node, bln) = annotated_node.split_once(':').unwrap();
+
+            stack.push(node.parse::<usize>().map_err(NewickError::ParseIntError)?);
+            bl_stack.push(bln.parse::<f32>().map_err(NewickError::ParseFloatError)?);
+        }
+
+        i += 1;
     }
-    let mut ancestry: Ancestry = Vec::new();
-    let mut bls: Vec<[f32; 2]> = Vec::new();
-    _get_cherries_recursive_inner_with_bls(
-        &mut ancestry,
-        &mut bls,
-        &newick[..newick.len() - 1],
-        false,
-    );
-    (ancestry, bls)
+
+    Ok((ancestry, bls))
 }
 
 /// Build newick string from a vector of pairs
@@ -477,9 +514,11 @@ mod tests {
         let ancestry: Ancestry;
         let bls: Vec<[f32; 2]>;
         if has_parents(newick) {
-            (ancestry, bls) = get_cherries_with_bls(newick);
+            (ancestry, bls) =
+                get_cherries_with_bls(newick).expect("failed to get cherries with branch lengths");
         } else {
-            (ancestry, bls) = get_cherries_no_parents_with_bls(newick);
+            (ancestry, bls) = get_cherries_no_parents_with_bls(newick)
+                .expect("failed to get cherries with branch lengths (no parents)");
         }
 
         // Verify the ancestry

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -237,7 +237,7 @@ pub fn order_cherries(ancestry: &mut Ancestry) {
 /// 0 2 2
 /// 0 8 8
 /// 0 1 1
-pub fn order_cherries_no_parents(ancestry: &mut Ancestry) {
+pub fn order_cherries_no_parents(ancestry: &mut Ancestry) -> Vec<usize> {
     let num_cherries = ancestry.len();
     let mut to_sort: Vec<usize> = Vec::with_capacity(num_cherries);
     let mut visited: HashMap<usize, usize> = HashMap::new();
@@ -259,10 +259,12 @@ pub fn order_cherries_no_parents(ancestry: &mut Ancestry) {
 
     // Note: using a stable sort is important to keep the order of cherries
     let mut temp = Ancestry::with_capacity(num_cherries);
-    for i in indices {
-        temp.push(ancestry[i]);
+    for i in &indices {
+        temp.push(ancestry[*i]);
     }
     *ancestry = temp;
+
+    indices
 }
 
 /// A Fenwick Tree (Binary Indexed Tree) for efficiently calculating prefix sums


### PR DESCRIPTION
Fixes recursion errors in to_matrix and, more importantly, tests related to the matrix format, where the Newick strings were ill-formatted.