### PR TITLE
refactor: unify newick --> matrix conversion in rust and tests in python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,16 +417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,37 +429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -501,10 +460,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "phylo2vec"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
- "ndarray",
  "rand",
  "regex",
  "rstest",
@@ -703,12 +661,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"

--- a/phylo2vec/Cargo.toml
+++ b/phylo2vec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phylo2vec"
 # Rust core version
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -15,7 +15,6 @@ thiserror = "2.0.12"
 [dev-dependencies]
 rstest = "0.23.0"
 criterion = { version = "0.5", features = ["html_reports"] }
-ndarray = "*"
 
 [[bin]]
 name = "profile_main"

--- a/py-phylo2vec/tests/test_base.py
+++ b/py-phylo2vec/tests/test_base.py
@@ -8,13 +8,16 @@ from ete3 import Tree
 from phylo2vec.base.ancestry import from_ancestry, to_ancestry
 from phylo2vec.base.edges import from_edges, to_edges
 from phylo2vec.base.newick import from_newick, to_newick
+from phylo2vec.utils.matrix import sample_matrix
+from phylo2vec.utils.newick import remove_parent_labels
 from phylo2vec.utils.vector import sample_vector
 from .config import MIN_N_LEAVES, MAX_N_LEAVES, N_REPEATS
 
 
 @pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES + 1))
 def test_v2newick2v(n_leaves):
-    """Test that v to newick to converted_v leads to v == converted_v
+    """Test that v to newick to converted_v
+    via `from_newick` leads to v == converted_v
 
     Parameters
     ----------
@@ -26,6 +29,28 @@ def test_v2newick2v(n_leaves):
         newick = to_newick(v)
         v2 = from_newick(newick)
         assert np.all(v == v2)
+
+
+@pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES + 1))
+def test_m2newick2m(n_leaves):
+    """
+    Test that m to newick to converted_m
+    via `from_newick` leads to m == converted_m
+
+    Parameters
+    ----------
+    n_leaves : int
+        Number of leaves
+    """
+    for _ in range(N_REPEATS):
+        m = sample_matrix(n_leaves)
+        newick = to_newick(m)
+        m2 = from_newick(newick)
+        assert np.allclose(m, m2, atol=1e-6)
+
+        newick_no_parents = remove_parent_labels(newick)
+        m3 = from_newick(newick_no_parents)
+        assert np.allclose(m, m3, atol=1e-6)
 
 
 @pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES + 1))


### PR DESCRIPTION
Current Python API fails when calling from_newick when a Newick string has branch lengths but no parents. This commit unifies to_matrix/to_matrix_no_parents in Rust under one function (similar to to_vector) and adds relevant matrix tests in Python.