### PR TITLE
feat: cophenetic distances from matrix format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "phylo2vec"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "rand",

--- a/phylo2vec/Cargo.toml
+++ b/phylo2vec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phylo2vec"
 # Rust core version
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/phylo2vec/src/tree_vec/ops/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/mod.rs
@@ -190,18 +190,18 @@ mod tests {
     }
 
     #[rstest]
-    #[case(vec![0], false, vec![vec![0, 2], vec![2, 0]])]
-    #[case(vec![0], true, vec![vec![0, 1], vec![1, 0]])]
-    #[case(vec![0, 1, 2], false, vec![vec![0, 3, 4, 4], vec![3, 0, 3, 3], vec![4, 3, 0, 2], vec![4, 3, 2, 0]])]
-    #[case(vec![0, 1, 2], true, vec![vec![0, 2, 3, 3], vec![2, 0, 3, 3], vec![3, 3, 0, 2], vec![3, 3, 2, 0]])]
-    #[case(vec![0, 0, 1], false, vec![vec![0, 4, 2, 4], vec![4, 0, 4, 2], vec![2, 4, 0, 4], vec![4, 2, 4, 0]])]
-    #[case(vec![0, 0, 1], true, vec![vec![0, 3, 2, 3], vec![3, 0, 3, 2], vec![2, 3, 0, 3], vec![3, 2, 3, 0]])]
+    #[case(vec![0], vec![vec![0, 2], vec![2, 0]])]
+    // #[case(vec![0], true, vec![vec![0, 1], vec![1, 0]])]
+    #[case(vec![0, 1, 2], vec![vec![0, 3, 4, 4], vec![3, 0, 3, 3], vec![4, 3, 0, 2], vec![4, 3, 2, 0]])]
+    // #[case(vec![0, 1, 2], true, vec![vec![0, 2, 3, 3], vec![2, 0, 3, 3], vec![3, 3, 0, 2], vec![3, 3, 2, 0]])]
+    #[case(vec![0, 0, 1], vec![vec![0, 4, 2, 4], vec![4, 0, 4, 2], vec![2, 4, 0, 4], vec![4, 2, 4, 0]])]
+    // #[case(vec![0, 0, 1], true, vec![vec![0, 3, 2, 3], vec![3, 0, 3, 2], vec![2, 3, 0, 3], vec![3, 2, 3, 0]])]
     fn test_cophenetic_distances(
         #[case] v: Vec<usize>,
-        #[case] unrooted: bool,
+        // #[case] unrooted: bool,
         #[case] expected: Vec<Vec<usize>>,
     ) {
-        assert_eq!(cophenetic_distances(&v, unrooted), expected);
+        assert_eq!(cophenetic_distances(&v), expected);
     }
 
     /// Test the conversion of a Newick string without parents to a vector

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -359,70 +359,89 @@ pub fn build_vector(cherries: &Ancestry) -> Vec<usize> {
     v
 }
 
-/// Get the cophenetic distances from the Phylo2Vec vector
+/// Generic function to calculate the cophenetic distance of a tree from
+/// a Phylo2Vec vector with or without branch lengths.
 /// Output is a pairwise distance matrix of dimensions n x n
-///
-/// # Example
-/// ```
-/// use phylo2vec::tree_vec::ops::vector::cophenetic_distances;
-///
-/// let v = vec![0, 0, 0, 1, 3, 3, 1, 4, 4];
-/// let dist = cophenetic_distances(&v, false);
-/// ```
-pub fn cophenetic_distances(v: &[usize], unrooted: bool) -> Vec<Vec<usize>> {
-    let mut ancestry = get_ancestry(v);
+/// where n = number of leaves.
+/// Each distance corresponds to the sum of the branch lengths between two leaves
+/// Inspired from the `cophenetic` function in the `ape` package: https://github.com/emmanuelparadis/ape
+pub fn _cophenetic_distances(v: &[usize], bls: Option<&Vec<[f32; 2]>>) -> Vec<Vec<f32>> {
+    let k = v.len();
+    let ancestry = get_ancestry(v);
 
-    if unrooted {
-        // Base case for unrooted trees: Simply two nodes connected to each other by a single edge
-        if v.len() == 1 {
-            return vec![vec![0, 1], vec![1, 0]];
-        }
-        let nrows = ancestry.len();
-        let ncols = ancestry[0].len();
-        ancestry[nrows - 1][ncols - 1] = ancestry.iter().flatten().max().unwrap() - 1;
-    }
+    let bls = match bls {
+        Some(b) => b.to_vec(),
+        None => vec![[1.0; 2]; v.len()],
+    };
 
-    let n_leaves = v.len() + 1;
-    let size = 2 * n_leaves - 1;
-    let mut dist: Vec<Vec<usize>> = vec![vec![0; size]; size];
+    // Note: unrooted option was removed.
+    // Originally implemented to match tr.unroot() in ete3
+    // But now prefer to operate such that unrooting
+    // preserves total branch lengths (compatible with ape,
+    // and ete3, see https://github.com/etetoolkit/ete/pull/344)
+
+    // Dist shape: N_nodes x N_nodes
+    let mut dist: Vec<Vec<f32>> = vec![vec![0.0; 2 * k + 1]; 2 * k + 1];
     let mut all_visited: Vec<usize> = Vec::new();
 
-    for i in 0..(n_leaves - 1) {
-        let [c1, c2, p] = ancestry[n_leaves - i - 2];
+    for i in 0..k {
+        let [c1, c2, p] = ancestry[k - i - 1];
+        let [bl1, bl2] = bls[k - i - 1];
 
         if !all_visited.is_empty() {
-            // Iterate over all_visited except the last element
             for &visited in &all_visited[0..all_visited.len() - 1] {
-                let dist_from_visited = dist[p][visited] + 1;
-                // c1 to visited
-                dist[c1][visited] = dist_from_visited;
-                dist[visited][c1] = dist_from_visited;
-                // c2 to visited
-                dist[c2][visited] = dist_from_visited;
-                dist[visited][c2] = dist_from_visited;
+                let dist1 = dist[p][visited] + bl1;
+                let dist2 = dist[p][visited] + bl2;
+
+                dist[c1][visited] = dist1;
+                dist[visited][c1] = dist1;
+                dist[c2][visited] = dist2;
+                dist[visited][c2] = dist2;
             }
         }
-        // c1 to c2: path length = 2
-        dist[c1][c2] = 2;
-        dist[c2][c1] = 2;
-        // c1 to parent: path length = 1
-        dist[c1][p] = 1;
-        dist[p][c1] = 1;
-        // c2 to parent: path length = 1
-        dist[c2][p] = 1;
-        dist[p][c2] = 1;
+
+        dist[c1][c2] = bl1 + bl2;
+        dist[c2][c1] = bl1 + bl2;
+
+        dist[c1][p] = bl1;
+        dist[p][c1] = bl1;
+
+        dist[c2][p] = bl2;
+        dist[p][c2] = bl2;
 
         all_visited.push(c1);
         all_visited.push(c2);
         all_visited.push(p);
     }
 
-    // Extract the top-left n_leaves x n_leaves submatrix
-    let mut result: Vec<Vec<usize>> = vec![vec![0; n_leaves]; n_leaves];
+    let n_leaves = k + 1;
+    let mut result: Vec<Vec<f32>> = vec![vec![0.0; n_leaves]; n_leaves];
     for i in 0..n_leaves {
         for j in 0..n_leaves {
             result[i][j] = dist[i][j];
         }
     }
+
     result
+}
+
+/// Get the cophenetic distances from the Phylo2Vec vector
+/// Output is a pairwise distance matrix of dimensions n x n
+/// where n = number of leaves.
+///
+/// # Example
+/// ```
+/// use phylo2vec::tree_vec::ops::vector::cophenetic_distances;
+///
+/// let v = vec![0, 0, 0, 1, 3, 3, 1, 4, 4];
+/// let dist = cophenetic_distances(&v);
+/// ```
+pub fn cophenetic_distances(v: &[usize]) -> Vec<Vec<usize>> {
+    let result = _cophenetic_distances(v, None);
+
+    // Convert f32 to usize
+    result
+        .iter()
+        .map(|row| row.iter().map(|&x| x as usize).collect())
+        .collect()
 }

--- a/py-phylo2vec/phylo2vec/metrics/pairwise.py
+++ b/py-phylo2vec/phylo2vec/metrics/pairwise.py
@@ -1,27 +1,46 @@
 """Pairwise distance metrics for nodes within phylogenetic trees."""
 
+import warnings
+import numpy as np
+
 from phylo2vec import _phylo2vec_core as core
 from phylo2vec.utils.vector import check_vector
 
 
-def cophenetic_distances(v, unrooted=False):
+def cophenetic_distances(vector_or_matrix, unrooted=False):
     """
     Compute the (topological) cophenetic distance matrix
     for tree nodes from a Phylo2Vec vector.
 
     Parameters
     ----------
-    v : numpy.ndarray
-        Phylo2Vec vector
-    unrooted : bool, optional
-        Whether to consider the tree as unrooted or not, by default False
+    vector_or_matrix : numpy.array
+        Phylo2Vec vector (ndim == 1)/matrix (ndim == 2)
 
     Returns
     -------
     numpy.ndarray
         Cophenetic distance matrix
     """
-    return core.cophenetic_distances(v, unrooted)
+    if unrooted:
+        warnings.warn(
+            (
+                "Argument `unrooted` is ignored. It is deprecated and "
+                "will be removed in future versions. When ensuring "
+                "compatibility with `ape` and `ete` (mode='keep'), the "
+                "argument becomes unnecessary. "
+            ),
+            FutureWarning,
+        )
+    if vector_or_matrix.ndim == 2:
+        coph = core.cophenetic_distances_with_bls(vector_or_matrix)
+    elif vector_or_matrix.ndim == 1:
+        coph = core.cophenetic_distances(vector_or_matrix)
+    else:
+        raise ValueError(
+            "vector_or_matrix should either be a vector (ndim == 1) or matrix (ndim == 2)"
+        )
+    return np.asarray(coph)
 
 
 PAIRWISE_DISTANCES = {"cophenetic": cophenetic_distances}

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -65,8 +65,13 @@ fn sample_vector(n_leaves: usize, ordered: bool) -> Vec<usize> {
 }
 
 #[pyfunction]
-fn cophenetic_distances(input_vector: Vec<usize>, unrooted: bool) -> Vec<Vec<usize>> {
-    ops::vector::cophenetic_distances(&input_vector, unrooted)
+fn cophenetic_distances(input_vector: Vec<usize>) -> Vec<Vec<usize>> {
+    ops::vector::cophenetic_distances(&input_vector)
+}
+
+#[pyfunction]
+fn cophenetic_distances_with_bls(input_matrix: Vec<Vec<f32>>) -> Vec<Vec<f32>> {
+    ops::matrix::cophenetic_distances_with_bls(&input_matrix)
 }
 
 #[pyfunction]
@@ -129,6 +134,7 @@ fn _phylo2vec_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(check_m, m)?)?;
     m.add_function(wrap_pyfunction!(check_v, m)?)?;
     m.add_function(wrap_pyfunction!(cophenetic_distances, m)?)?;
+    m.add_function(wrap_pyfunction!(cophenetic_distances_with_bls, m)?)?;
     m.add_function(wrap_pyfunction!(find_num_leaves, m)?)?;
     m.add_function(wrap_pyfunction!(from_ancestry, m)?)?;
     m.add_function(wrap_pyfunction!(from_edges, m)?)?;

--- a/py-phylo2vec/tests/test_metrics.py
+++ b/py-phylo2vec/tests/test_metrics.py
@@ -7,12 +7,44 @@ from ete3 import Tree
 
 from phylo2vec.base.newick import to_newick
 from phylo2vec.metrics import cophenetic_distances
+from phylo2vec.utils.matrix import sample_matrix
 from phylo2vec.utils.vector import sample_vector
-from .config import MIN_N_LEAVES, N_REPEATS
+from .config import MIN_N_LEAVES, MAX_N_LEAVES, N_REPEATS
+
+MAX_N_LEAVES_COPH = MAX_N_LEAVES // 4
 
 
-@pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, 51))
-def test_cophenetic(n_leaves):
+def _cophenetic(n_leaves, sample_fn):
+    """Helper function to test cophenetic distances using a sample function."""
+
+    def coph_ete3(tr, n_leaves):
+        dmat = np.zeros((n_leaves, n_leaves))
+
+        for i in range(n_leaves):
+            for j in range(i):
+                dist = tr.get_distance(f"{i}", f"{j}", topology_only=False)
+                dmat[i, j] = dist
+                dmat[j, i] = dist
+
+        return dmat
+
+    for _ in range(N_REPEATS):
+        vector_or_matrix = sample_fn(n_leaves)
+
+        # tree with all branch lengths = 1
+        tr = Tree(to_newick(vector_or_matrix))
+
+        # Our distance matrix
+        dmat_p2v = cophenetic_distances(vector_or_matrix)
+
+        # ete3 distance matrix
+        dmat_ete3 = coph_ete3(tr, n_leaves)
+
+        assert np.allclose(dmat_p2v, dmat_ete3)
+
+
+@pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES_COPH))
+def test_cophenetic_vector(n_leaves):
     """Test that v to newick to converted_v leads to v == converted_v
 
     Parameters
@@ -21,36 +53,20 @@ def test_cophenetic(n_leaves):
         Number of leaves
     """
 
-    def coph_ete3(tr, n_leaves):
-        dmat = np.zeros((n_leaves, n_leaves))
+    _cophenetic(n_leaves, sample_vector)
 
-        for i in range(n_leaves):
-            for j in range(i):
-                dmat[i, j] = tr.get_distance(f"{i}", f"{j}", topology_only=False)
 
-        return dmat + dmat.T
+@pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES_COPH))
+def test_cophenetic_matrix(n_leaves):
+    """Test that v to newick to converted_v leads to v == converted_v
 
-    for _ in range(N_REPEATS):
-        v = sample_vector(n_leaves)
+    Parameters
+    ----------
+    n_leaves : int
+        Number of leaves
+    """
 
-        # tree with all branch lengths = 1
-        tr = Tree(to_newick(v))
-
-        # Our distance matrix
-        dmat_p2v = cophenetic_distances(v)
-
-        # ete3 distance matrix
-        dmat_ete3 = coph_ete3(tr, n_leaves)
-
-        assert np.array_equal(dmat_p2v, dmat_ete3)
-
-        # Test for unrooted trees
-        dmat_p2v_unr = cophenetic_distances(v, unrooted=True)
-
-        tr.unroot()
-        dmat_ete3_unr = coph_ete3(tr, n_leaves)
-
-        assert np.array_equal(dmat_p2v_unr, dmat_ete3_unr)
+    _cophenetic(n_leaves, sample_matrix)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cophenetic distance functions work with a vector (topological distance) or a matrix (traditional cophenetic distance with branch lengths) in Rust and Python.

Argument ```unrooted``` was removed from the Rust API: the priority is to be compatible with `ape` and `ete3`. `ape` preserves branch lengths with unrooting, and so does `ete3` with the ```mode='keep'``` option (https://github.com/etetoolkit/ete/pull/344), meaning that there's no need for an optional "unrooted" argument in these functions.