### PR TITLE
refactor: move label_mapping functions to rust and make them more robust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "phylo2vec"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "rand",

--- a/phylo2vec/Cargo.toml
+++ b/phylo2vec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phylo2vec"
 # Rust core version
-version = "0.2.2"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/phylo2vec/src/tree_vec/ops/newick/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/newick/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use thiserror;
 
 use crate::tree_vec::types::{Ancestry, Pairs};
@@ -184,6 +185,7 @@ pub fn get_cherries_no_parents(newick: &str) -> Result<Ancestry, NewickError> {
 
     Ok(ancestry)
 }
+
 pub fn get_cherries_no_parents_with_bls(
     newick: &str,
 ) -> Result<(Ancestry, Vec<[f32; 2]>), NewickError> {
@@ -420,11 +422,201 @@ pub fn find_num_leaves(newick: &str) -> usize {
     result.len()
 }
 
+/// Create an integer-taxon label mapping (label_mapping)
+/// from a string-based newick (where leaves are strings)
+/// and produce a mapped integer-based newick (where leaves are integers).
+///
+/// Note 1: this does not check for the validity of the Newick string.
+///
+/// Note 2: the parent nodes are removed from the output,
+/// but the branch lengths/annotations are kept.
+///
+/// # Example
+/// ```
+/// use phylo2vec::tree_vec::ops::newick::create_label_mapping;
+///
+/// let nw_str = "(((aaaaaaaaae,(aaaaaaaaaf,aaaaaaaaag)),aaaaaaaaaa),(aaaaaaaaab,(aaaaaaaaac,aaaaaaaaad)));";
+/// let (nw_int, label_mapping) = create_label_mapping(&nw_str);
+/// assert_eq!(nw_int, "(((0,(1,2)),3),(4,(5,6)));");
+/// assert_eq!(label_mapping.get(&0), Some(&"aaaaaaaaae".to_string()));
+///
+/// // With branch lengths and parents
+/// let nw_str2 = "(((aaaaaaaaae:2.5,(aaaaaaaaaf:1,aaaaaaaaag:1)p0:0.1)p1:405,aaaaaaaaaa:1)p2:1,(aaaaaaaaab:1,(aaaaaaaaac:1,aaaaaaaaad:1)p3:1)p4:1)p5;";
+/// let (nw_int2, label_mapping2) = create_label_mapping(&nw_str2);
+/// assert_eq!(nw_int2, "(((0:2.5,(1:1,2:1):0.1):405,3:1):1,(4:1,(5:1,6:1):1):1);");
+/// assert_eq!(label_mapping2.get(&1), Some(&"aaaaaaaaaf".to_string()));
+/// ```
+pub fn create_label_mapping(newick: &str) -> (String, HashMap<usize, String>) {
+    if newick.is_empty() {
+        return (String::new(), HashMap::<usize, String>::new());
+    }
+
+    let mut newick_int = String::new();
+    // Label mapping
+    // Key: leaf index (integer)
+    // Value: leaf label (string)
+    let mut label_mapping: HashMap<usize, String> = HashMap::new();
+    let mut next_leaf: usize = 0;
+
+    let newick_bytes = newick.as_bytes();
+
+    let mut i: usize = 0;
+
+    while i < newick.len() {
+        // Next character
+        let c: char = newick_bytes[i] as char;
+
+        if c != '(' && c != ',' && c != ';' && c != ')' {
+            // Get the next node
+            let (leaf, end) = node_substr(newick, i);
+            i = end - 1;
+
+            // Push the next leaf to the integer Newick
+            newick_int.push_str(&next_leaf.to_string());
+
+            match leaf.split_once(':') {
+                Some((n, bl)) => {
+                    // Add the node to the label mapping
+                    label_mapping.insert(next_leaf, n.to_string());
+                    // Push the branch length to the integer Newick
+                    newick_int.push(':');
+                    newick_int.push_str(bl);
+                }
+                None => {
+                    // No branch length => add the node as it is to the label mapping
+                    label_mapping.insert(next_leaf, leaf.to_string());
+                }
+            }
+
+            // Increment the next leaf index
+            next_leaf += 1;
+        } else {
+            newick_int.push(c);
+
+            // Process internal/parent nodes
+            if c == ')' {
+                i += 1;
+                let (parent, end) = node_substr(newick, i);
+                i = end - 1;
+
+                if let Some((_, bl)) = parent.split_once(':') {
+                    // Push the parent branch length to the integer Newick
+                    // Note: the parent node itself is not pushed
+                    newick_int.push(':');
+                    newick_int.push_str(bl);
+                }
+            }
+        }
+
+        i += 1;
+    }
+
+    (newick_int, label_mapping)
+}
+
+/// Apply an integer-taxon label mapping (label_mapping)
+/// to an integer-based newick (where leaves are integers)
+/// and produce a mapped Newick (where leaves are strings (taxa))
+///
+/// For more details, see `create_label_mapping`.
+///
+/// Note 1: this does not check for the validity of the Newick string.
+///
+/// Note 2: the parent nodes are removed from the output,
+/// but the branch lengths/annotations are kept.
+///
+/// # Example
+/// ```
+/// use std::collections::HashMap;
+/// use phylo2vec::tree_vec::ops::newick::apply_label_mapping;
+///
+/// let nw_int = "(((0:1,(1:1,2:1):1):1,3:1):1,(4:1,(5:1,6:1):1):1);";
+/// let label_mapping = HashMap::<usize, String>::from(
+///     [
+///         (0, "aaaaaaaaae".into()), (1, "aaaaaaaaaf".into()),
+///         (2, "aaaaaaaaag".into()), (3, "aaaaaaaaaa".into()),
+///         (4, "aaaaaaaaab".into()), (5, "aaaaaaaaac".into()),
+///         (6, "aaaaaaaaad".into())
+///     ]
+/// );
+/// let nw_str = apply_label_mapping(&nw_int, &label_mapping).expect("Oops");
+/// assert_eq!(
+///     nw_str,
+///     "(((aaaaaaaaae:1,(aaaaaaaaaf:1,aaaaaaaaag:1):1)\
+///     :1,aaaaaaaaaa:1):1,(aaaaaaaaab:1,(aaaaaaaaac:1,aaaaaaaaad:1)\
+///     :1):1);"
+/// );
+/// ```
+pub fn apply_label_mapping(
+    newick: &str,
+    label_mapping: &HashMap<usize, String>,
+) -> Result<String, NewickError> {
+    if newick.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut newick_str = String::new();
+    let newick_bytes = newick.as_bytes();
+
+    let mut i: usize = 0;
+
+    while i < newick.len() {
+        let c: char = newick_bytes[i] as char;
+
+        if c != '(' && c != ',' && c != ';' && c != ')' {
+            // Get the next node
+            let (leaf, end) = node_substr(newick, i);
+            i = end - 1;
+
+            match leaf.split_once(':') {
+                Some((n, bl)) => {
+                    // Add the node to the label mapping
+                    let leaf_int = n.parse::<usize>().map_err(NewickError::ParseIntError)?;
+
+                    // Push the mapped leaf to the string Newick
+                    newick_str.push_str(&label_mapping[&leaf_int]);
+
+                    // Push the branch length to the string Newick
+                    newick_str.push(':');
+                    newick_str.push_str(bl);
+                }
+                None => {
+                    let leaf_int = leaf.parse::<usize>().map_err(NewickError::ParseIntError)?;
+
+                    // No branch length => add the mapped node as it is to the string Newick
+                    newick_str.push_str(&label_mapping[&leaf_int]);
+                }
+            }
+        } else {
+            newick_str.push(c);
+
+            // Process internal/parent nodes
+            if c == ')' {
+                i += 1;
+                let (parent, end) = node_substr(newick, i);
+                i = end - 1;
+
+                if let Some((_, bl)) = parent.split_once(':') {
+                    // Push the parent branch length to the string Newick
+                    // Note: the parent node itself is not pushed
+                    newick_str.push(':');
+                    newick_str.push_str(bl);
+                }
+            }
+        }
+
+        i += 1;
+    }
+
+    Ok(newick_str)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tree_vec::ops::{parse_matrix, to_newick_from_matrix, to_newick_from_vector};
     use crate::utils::{sample_matrix, sample_vector};
+    use rand::{distributions::Alphanumeric, Rng};
     use rstest::*;
 
     #[rstest]
@@ -524,5 +716,53 @@ mod tests {
         // Verify the branch lengths
         assert_eq!(bls.len(), expected_bls.len()); // Ensure the number of branch lengths is correct
         assert_eq!(bls, expected_bls); // Ensure branch lengths match the expected
+    }
+
+    // Generate a random Newick string with random taxon labels
+    fn generate_random_string_newick(n_leaves: usize) -> String {
+        // Create random taxon labels
+        // Alphanumeric: a-z, A-Z and 0-9.
+        let mut rng = rand::thread_rng();
+        let mut mapping = HashMap::<usize, String>::new();
+
+        for i in 0..n_leaves {
+            let taxon: String = (&mut rng)
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .map(char::from)
+                .collect();
+            mapping.insert(i, taxon);
+        }
+
+        // Generate a random newick
+        let v = sample_vector(n_leaves, false);
+        let nw1 = remove_parent_labels(&to_newick_from_vector(&v));
+
+        // Map new taxon labels to each leaf
+        apply_label_mapping(&nw1, &mapping).expect("Failed to apply label mapping")
+    }
+
+    #[rstest]
+    #[case(10)]
+    #[case(100)]
+    #[case(1000)]
+    fn test_label_mappping(#[case] n_leaves: usize) {
+        let nw_str = generate_random_string_newick(n_leaves);
+
+        // Get the "sorted" version of the integer Newick
+        // Ex: nw1 = "(((0,(1,5)),((2,((3,9),7)),(6,8))),4);"
+        // Ex: nw3 = "(((0,(1,2)),((3,((4,5),6)),(7,8))),9);"
+        let (nw_int, mapping) = create_label_mapping(&nw_str);
+
+        let nw_str2 = apply_label_mapping(&nw_int, &mapping).expect("Oops");
+
+        // Check if nw2 (first Newick with taxon labels) == nw4 (second Newick with taxon labels)
+        // Note: asserting the equality of a random integer Newick from phylo2vec with
+        // a new integer Newick from create + apply_label_mapping does not work
+        // because the order of the leaves is not guaranteed to be the same.
+        // Ex: nw1 = "(((0,(1,5)),((2,((3,9),7)),(6,8))),4);"
+        // Ex: nw3 = "(((0,(1,2)),((3,((4,5),6)),(7,8))),9);"
+        // Same topology, but different leaf placements
+        assert_eq!(nw_str, nw_str2);
     }
 }

--- a/phylo2vec/src/tree_vec/ops/newick/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/newick/mod.rs
@@ -746,7 +746,7 @@ mod tests {
     #[case(10)]
     #[case(100)]
     #[case(1000)]
-    fn test_label_mappping(#[case] n_leaves: usize) {
+    fn test_label_mapping(#[case] n_leaves: usize) {
         let nw_str = generate_random_string_newick(n_leaves);
 
         // Get the "sorted" version of the integer Newick

--- a/py-phylo2vec/phylo2vec/utils/newick.py
+++ b/py-phylo2vec/phylo2vec/utils/newick.py
@@ -74,39 +74,7 @@ def create_label_mapping(newick):
     label_mapping : Dict str --> str
         Mapping of leaf labels (integers converted to string) to taxa
     """
-    label_mapping = {}
-
-    newick = newick[:-1]  # For ";"
-
-    newick_int = newick
-
-    def do_reduce(newick, newick_clean, j):
-        for i, char in enumerate(newick):
-            if char == "(":
-                open_idx = i + 1
-            elif char == ")":
-                for child in newick[open_idx:i].split(",", 2):
-                    if child not in label_mapping:
-                        # Update the newick with an integer
-                        newick_clean = newick_clean.replace(child, f"{j}")
-
-                        # Add the taxon to the mapping
-                        label_mapping[f"{j}"] = child
-                        j += 1
-
-                parent = newick[i + 1 :].split(",", 1)[0].split(")", 1)[0]
-
-                newick = newick.replace(
-                    newick[open_idx - 1 : i + 1 + len(parent)], f"{j - 1}"
-                )
-
-                newick_clean = newick_clean.replace(parent, "")
-
-                return do_reduce(newick, newick_clean, j)
-
-        return newick_clean
-
-    newick_int = do_reduce(newick, newick_int, 0) + ";"
+    newick_int, label_mapping = core.create_label_mapping(newick)
 
     return newick_int, label_mapping
 
@@ -129,9 +97,6 @@ def apply_label_mapping(newick, label_mapping):
     newick : str
         Newick with string labels
     """
-    for i in range(len(label_mapping)):
-        key = f"{len(label_mapping) - i - 1}"
+    newick_str = core.apply_label_mapping(newick, label_mapping)
 
-        newick = newick.replace(key, label_mapping[key])
-
-    return newick
+    return newick_str

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -132,8 +132,14 @@ fn remove_leaf(mut input_vector: Vec<usize>, leaf: usize) -> (Vec<usize>, usize)
 
 #[pyfunction]
 fn apply_label_mapping(newick: String, label_mapping: HashMap<usize, String>) -> PyResult<String> {
-    let newick_int = ops::newick::apply_label_mapping(&newick, &label_mapping)
-        .expect("Failed to apply label mapping");
+    let result = ops::newick::apply_label_mapping(&newick, &label_mapping);
+
+    // Map the potential NewickError to a PyValueErr
+    // https://pyo3.rs/v0.22.3/function/error-handling#foreign-rust-error-types
+    let newick_int = result.map_err(|e| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Label mapping failed: {}", e))
+    })?;
+
     Ok(newick_int)
 }
 

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 
 use phylo2vec::tree_vec::ops;
 use phylo2vec::utils;
+use std::collections::HashMap;
 
 #[pyfunction]
 fn to_newick_from_vector(input_vector: Vec<usize>) -> PyResult<String> {
@@ -110,13 +111,13 @@ fn has_parents(newick: &str) -> bool {
 }
 
 #[pyfunction]
-fn remove_branch_lengths(newick: &str) -> String {
-    ops::newick::remove_branch_lengths(newick)
+fn remove_branch_lengths(newick: &str) -> PyResult<String> {
+    Ok(ops::newick::remove_branch_lengths(newick))
 }
 
 #[pyfunction]
-fn remove_parent_labels(newick: &str) -> String {
-    ops::newick::remove_parent_labels(newick)
+fn remove_parent_labels(newick: &str) -> PyResult<String> {
+    Ok(ops::newick::remove_parent_labels(newick))
 }
 
 #[pyfunction]
@@ -129,17 +130,31 @@ fn remove_leaf(mut input_vector: Vec<usize>, leaf: usize) -> (Vec<usize>, usize)
     ops::remove_leaf(&mut input_vector, leaf)
 }
 
+#[pyfunction]
+fn apply_label_mapping(newick: String, label_mapping: HashMap<usize, String>) -> PyResult<String> {
+    let newick_int = ops::newick::apply_label_mapping(&newick, &label_mapping)
+        .expect("Failed to apply label mapping");
+    Ok(newick_int)
+}
+
+#[pyfunction]
+fn create_label_mapping(newick: String) -> PyResult<(String, HashMap<usize, String>)> {
+    Ok(ops::newick::create_label_mapping(&newick))
+}
+
 /// This module is exposed to Python.
 /// The line below raises an issue in DeepSource stating that this function's cyclomatic complexity is higher than threshold
 /// the analyzer does not understand that this is an API exposure function, hence the comment above to skip over this occurrence.
 #[pymodule]
 fn _phylo2vec_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(add_leaf, m)?)?;
+    m.add_function(wrap_pyfunction!(apply_label_mapping, m)?)?;
     m.add_function(wrap_pyfunction!(build_newick, m)?)?;
     m.add_function(wrap_pyfunction!(check_m, m)?)?;
     m.add_function(wrap_pyfunction!(check_v, m)?)?;
     m.add_function(wrap_pyfunction!(cophenetic_distances, m)?)?;
     m.add_function(wrap_pyfunction!(cophenetic_distances_with_bls, m)?)?;
+    m.add_function(wrap_pyfunction!(create_label_mapping, m)?)?;
     m.add_function(wrap_pyfunction!(find_num_leaves, m)?)?;
     m.add_function(wrap_pyfunction!(from_ancestry, m)?)?;
     m.add_function(wrap_pyfunction!(from_edges, m)?)?;


### PR DESCRIPTION
Changes:
 * Move python functions ```create_label_mapping``` and ```apply_label_mapping``` to rust.
 * Make ```apply_label_mapping``` more robust (not a naive string replace)
 * Add unit tests in Rust for those functions