### PR TITLE
refactor: rename 'shuffle' argument in QS

### DIFF
--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -616,7 +616,7 @@ pub fn get_common_ancestor(v: &[usize], node1: usize, node2: usize) -> usize {
 /// // The 7th taxon is now represented by 5
 /// assert_eq!(label_mapping, vec![0, 1, 2, 3, 6, 4, 5]);
 /// ```
-pub fn queue_shuffle(v: &[usize], shuffle: bool) -> (Vec<usize>, Vec<usize>) {
+pub fn queue_shuffle(v: &[usize], shuffle_cherries: bool) -> (Vec<usize>, Vec<usize>) {
     let pairs = get_pairs(v);
     let ancestry = get_ancestry_from_pairs(&pairs);
 
@@ -634,8 +634,8 @@ pub fn queue_shuffle(v: &[usize], shuffle: bool) -> (Vec<usize>, Vec<usize>) {
     while queue.len() < k {
         let [c1, c2, _] = ancestry[queue[j] - n_leaves];
 
-        // `shuffle` allows to randomly permutate the order of children
-        let child_order = if shuffle && rand::random() {
+        // `shuffle_cherries` allows to randomly permutate the order of children
+        let child_order = if shuffle_cherries && rand::random() {
             [c2, c1]
         } else {
             [c1, c2]

--- a/py-phylo2vec/phylo2vec/utils/vector.py
+++ b/py-phylo2vec/phylo2vec/utils/vector.py
@@ -95,7 +95,7 @@ def add_leaf(v, leaf, pos) -> np.ndarray:
     return np.asarray(v_add)
 
 
-def queue_shuffle(v, shuffle=False) -> Tuple[np.ndarray, List[int]]:
+def queue_shuffle(v, shuffle_cherries=False) -> Tuple[np.ndarray, List[int]]:
     """
     Produce an ordered version (i.e., birth-death process version)
     of a Phylo2Vec vector using the Queue Shuffle algorithm.
@@ -109,8 +109,9 @@ def queue_shuffle(v, shuffle=False) -> Tuple[np.ndarray, List[int]]:
     ----------
     v : numpy.ndarray
         Phylo2Vec vector
-    shuffle : bool, optional
-        If True, shuffle at random the children columns in the ancestry matrix
+    shuffle_cherries : bool, optional
+        If True, shuffle at random the order of the cherries in the ancestry matrix
+        (i.e., the first two columns of the ancestry matrix).
 
     Returns
     -------
@@ -121,12 +122,12 @@ def queue_shuffle(v, shuffle=False) -> Tuple[np.ndarray, List[int]]:
         index: leaf
         value: new leaf index in the reordered vector
     """
-    v_new, vec_mapping = core.queue_shuffle(v, shuffle)
+    v_new, vec_mapping = core.queue_shuffle(v, shuffle_cherries)
 
     return np.asarray(v_new), vec_mapping
 
 
-def reorder_v(reorder_method, v_old, label_mapping_old, shuffle=False):
+def reorder_v(reorder_method, v_old, label_mapping_old, shuffle_cols=False):
     """Shuffle v by reordering leaf labels
 
     Current pipeline: get ancestry matrix --> reorder --> re-build vector
@@ -143,8 +144,9 @@ def reorder_v(reorder_method, v_old, label_mapping_old, shuffle=False):
     label_mapping_old : dict[int, str]
         Current mapping of node label (integer) to taxa
         Note: Will be deprecated in a future release; see `queue_shuffle` instead.
-    shuffle : bool, optional
-        If True, shuffle at random the children columns in the ancestry matrix
+    shuffle_cols : bool, optional
+        If True, shuffle at random the order of the cherries in the ancestry matrix
+        (i.e., the first two columns of the ancestry matrix).
 
 
     Returns
@@ -165,7 +167,7 @@ def reorder_v(reorder_method, v_old, label_mapping_old, shuffle=False):
 
     # Reorder M
     if reorder_method == "birth_death":
-        v_new, vec_mapping = queue_shuffle(v_old, shuffle=shuffle)
+        v_new, vec_mapping = queue_shuffle(v_old, shuffle_cherries=shuffle_cols)
         # For compatibility with the old label mapping (for _hc)
         label_mapping_new = {
             vec_mapping[i]: label_mapping_old[i] for i in range(len(vec_mapping))

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -154,8 +154,8 @@ fn get_common_ancestor(v: Vec<usize>, node1: usize, node2: usize) -> usize {
 }
 
 #[pyfunction]
-fn queue_shuffle(v: Vec<usize>, shuffle: bool) -> (Vec<usize>, Vec<usize>) {
-    ops::vector::queue_shuffle(&v, shuffle)
+fn queue_shuffle(v: Vec<usize>, shuffle_cherries: bool) -> (Vec<usize>, Vec<usize>) {
+    ops::vector::queue_shuffle(&v, shuffle_cherries)
 }
 
 /// This module is exposed to Python.

--- a/r-phylo2vec/R/extendr-wrappers.R
+++ b/r-phylo2vec/R/extendr-wrappers.R
@@ -81,8 +81,13 @@ has_branch_lengths <- function(newick) .Call(wrap__has_branch_lengths, newick)
 #'
 #' for more details, see https://doi.org/10.1093/gbe/evad213
 #'
+#' @param vector A Phylo2Vec vector (i.e., a vector of integers)
+#' @param shuffle_cherries If true, the algorithm will shuffle cherries (i.e., pairs of leaves)
+#' @return A list with two elements:
+#' - `v`: The ordered Phylo2Vec vector
+#' - `mapping`: A mapping of the original labels to the new labels
 #' @export
-queue_shuffle <- function(vector, shuffle) .Call(wrap__queue_shuffle, vector, shuffle)
+queue_shuffle <- function(vector, shuffle_cherries) .Call(wrap__queue_shuffle, vector, shuffle_cherries)
 
 #' Remove a leaf from a Phylo2Vec vector
 #' @export

--- a/r-phylo2vec/man/queue_shuffle.Rd
+++ b/r-phylo2vec/man/queue_shuffle.Rd
@@ -5,7 +5,19 @@
 \title{Produce an ordered version (i.e., birth-death process version)
 of a Phylo2Vec vector using the Queue Shuffle algorithm.}
 \usage{
-queue_shuffle(vector, shuffle)
+queue_shuffle(vector, shuffle_cherries)
+}
+\arguments{
+\item{vector}{A Phylo2Vec vector (i.e., a vector of integers)}
+
+\item{shuffle_cherries}{If true, the algorithm will shuffle cherries (i.e., pairs of leaves)}
+}
+\value{
+A list with two elements:
+\itemize{
+\item \code{v}: The ordered Phylo2Vec vector
+\item \code{mapping}: A mapping of the original labels to the new labels
+}
 }
 \description{
 Queue Shuffle ensures that the output tree is ordered,

--- a/r-phylo2vec/src/rust/src/lib.rs
+++ b/r-phylo2vec/src/rust/src/lib.rs
@@ -310,11 +310,16 @@ fn get_common_ancestor(vector: Vec<i32>, node1: i32, node2: i32) -> i32 {
 ///
 /// for more details, see https://doi.org/10.1093/gbe/evad213
 ///
+/// @param vector A Phylo2Vec vector (i.e., a vector of integers)
+/// @param shuffle_cherries If true, the algorithm will shuffle cherries (i.e., pairs of leaves)
+/// @return A list with two elements:
+/// - `v`: The ordered Phylo2Vec vector
+/// - `mapping`: A mapping of the original labels to the new labels
 /// @export
 #[extendr]
-fn queue_shuffle(vector: Vec<i32>, shuffle: bool) -> List {
+fn queue_shuffle(vector: Vec<i32>, shuffle_cherries: bool) -> List {
     let v_usize: Vec<usize> = as_usize(vector);
-    let (v_new, label_mapping) = ops::vector::queue_shuffle(&v_usize, shuffle);
+    let (v_new, label_mapping) = ops::vector::queue_shuffle(&v_usize, shuffle_cherries);
     list!(v = as_i32(v_new), mapping = as_i32(label_mapping))
 }
 


### PR DESCRIPTION
* 'shuffle' argument is a bit vague, esp. when the algo is called queue shuffle --> renamed to 'shuffle_cherries' to illustrate that we shuffle the processing order of certain cherries (at random)