### PR TITLE
fix: fix queue shuffle and dependent optimisation schemes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "phylo2vec"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "rand",

--- a/phylo2vec/Cargo.toml
+++ b/phylo2vec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phylo2vec"
 # Rust core version
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/phylo2vec/src/tree_vec/ops/matrix/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/matrix/mod.rs
@@ -25,26 +25,17 @@ use crate::tree_vec::ops::vector::{
 ///
 /// Assumes a valid Newick string. Relies on helper functions for processing.
 pub fn to_matrix(newick: &str) -> Vec<Vec<f32>> {
-    let (cherries, mut bls, row_idxs, bl_rows_to_swap) = if has_parents(newick) {
+    // Get the cherries and branch lengths
+    let (mut cherries, mut bls) = get_cherries_with_bls(newick)
+        .expect("failed to get cherries with branch lengths and no parents");
+
+    // Order the cherries in the ancestry matrix
+    let (row_idxs, bl_rows_to_swap) = if has_parents(newick) {
         // Case 1: Newick string with parent nodes
-
-        // Get the cherries and branch lengths
-        let (mut cherries, bls) =
-            get_cherries_with_bls(newick).expect("failed to get cherries with branch lengths");
-
-        // Order the cherries in the ancestry matrix
-        let (row_idxs, bl_rows_to_swap) = order_cherries(&mut cherries);
-        (cherries, bls, row_idxs, bl_rows_to_swap)
+        order_cherries(&mut cherries)
     } else {
         // Case 2: Newick string without parent nodes
-
-        // Get the cherries and branch lengths
-        let (mut cherries, bls) = get_cherries_with_bls(newick)
-            .expect("failed to get cherries with branch lengths and no parents");
-
-        // Order the cherries in the ancestry matrix
-        let (row_idxs, bl_rows_to_swap) = order_cherries_no_parents(&mut cherries);
-        (cherries, bls, row_idxs, bl_rows_to_swap)
+        order_cherries_no_parents(&mut cherries)
     };
 
     // Build the vector
@@ -247,9 +238,6 @@ mod tests {
         #[case] expected_distances: Vec<Vec<f32>>,
     ) {
         let distances = cophenetic_distances_with_bls(&matrix);
-
-        println!("Distances: {:?}", distances);
-        println!("Expected Distances: {:?}", expected_distances);
 
         let rtol = 1e-5;
         let atol = 1e-8;

--- a/phylo2vec/src/tree_vec/ops/mod.rs
+++ b/phylo2vec/src/tree_vec/ops/mod.rs
@@ -325,14 +325,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case(vec![0], vec![0], vec![0, 1])]
-    #[case(vec![0, 0], vec![0, 0], vec![0, 1, 2])]
-    #[case(vec![0, 0, 0], vec![0, 0, 0], vec![0, 1, 2, 3])]
-    #[case(vec![0, 2, 1, 6], vec![0, 0, 0, 3], vec![0, 3, 2, 4, 1])]
-    #[case(vec![0, 0, 1, 5, 5], vec![0, 0, 1, 0, 1], vec![0, 1, 4, 5, 2, 3])]
-    #[case(vec![0, 0, 0, 2, 5, 3], vec![0, 0, 0, 2, 3, 2], vec![0, 1, 2, 3, 6, 4, 5])]
-    #[case(vec![0, 0, 0, 2, 6, 3], vec![0, 0, 0, 2, 0, 5], vec![0, 1, 2, 5, 4, 3, 6])]
-    #[case(vec![0, 0, 0, 2, 7, 3], vec![0, 0, 0, 0, 3, 4], vec![0, 1, 3, 4, 5, 2, 6])]
+    #[case(vec![0], vec![0], vec![1, 0])]
+    #[case(vec![0, 0], vec![0, 1], vec![1, 2, 0])]
+    #[case(vec![0, 0, 0], vec![0, 1, 2], vec![1, 2, 3, 0])]
+    #[case(vec![0, 2, 1, 3], vec![0, 1, 1, 1], vec![2, 4, 0, 1, 3])]
+    #[case(vec![0, 0, 0, 2, 5, 3], vec![0, 1, 1, 2, 3, 2], vec![1, 5, 6, 4, 0, 2, 3])]
     fn test_queue_shuffle(
         #[case] v_input: Vec<usize>,
         #[case] v_expected: Vec<usize>,

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -698,9 +698,11 @@ pub fn queue_shuffle(v: &[usize], shuffle_cherries: bool) -> (Vec<usize>, Vec<us
     let mut node_code = Vec::new();
 
     while new_pairs.len() < k {
+        // Next row in the ancestry
         let [c2, c1, _] = ancestry[queue[j] - n_leaves];
 
         // `shuffle_cherries` allows to randomly permutate the order of children
+        // useful in optimisation algorithms
         let child_order = if shuffle_cherries && rand::random() {
             [c2, c1]
         } else {
@@ -709,18 +711,23 @@ pub fn queue_shuffle(v: &[usize], shuffle_cherries: bool) -> (Vec<usize>, Vec<us
 
         let next_leaf = j + 1;
 
+        // If the node code is empty, we are at the root
+        // Otherwise, we take the 2nd previous node code
         let new_pair = if node_code.is_empty() {
             (0, 1)
         } else {
             (node_code[j - 1], next_leaf)
         };
 
+        // Push the new pair to the output
         new_pairs.push(new_pair);
 
-        // Add internal nodes to the queue
+        // Process internal nodes
         for (i, &c) in child_order.iter().enumerate() {
             if c >= n_leaves {
+                // Add internal nodes to the queue
                 queue.push(c);
+                // Encode internal nodes in the node code
                 if i == 0 {
                     node_code.push(new_pair.0)
                 } else {
@@ -729,6 +736,7 @@ pub fn queue_shuffle(v: &[usize], shuffle_cherries: bool) -> (Vec<usize>, Vec<us
             }
         }
 
+        // Process leaf nodes --> update the label mapping
         if child_order[1] < n_leaves {
             label_mapping[new_pair.1] = c2;
         }
@@ -743,6 +751,7 @@ pub fn queue_shuffle(v: &[usize], shuffle_cherries: bool) -> (Vec<usize>, Vec<us
 
     let v_qs = from_pairs(&new_pairs);
 
+    // Check that the label mapping is unique
     {
         let unique: HashSet<_> = label_mapping.iter().copied().collect();
         assert_eq!(

--- a/phylo2vec/src/tree_vec/ops/vector.rs
+++ b/phylo2vec/src/tree_vec/ops/vector.rs
@@ -3,6 +3,7 @@ use crate::tree_vec::types::{Ancestry, Pair, Pairs};
 use crate::utils::is_unordered;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 /// Get all "pairs" from the Phylo2Vec vector
 /// using a for loop implementation.
@@ -86,7 +87,7 @@ pub fn from_pairs(pairs: &Pairs) -> Vec<usize> {
         cherries.push([c1, c2, std::cmp::max(c1, c2)]);
     }
 
-    order_cherries_no_parents(&mut cherries);
+    // order_cherries_no_parents(&mut cherries);
 
     build_vector(&cherries)
 }
@@ -155,10 +156,12 @@ pub fn get_ancestry(v: &[usize]) -> Ancestry {
 }
 
 pub fn from_ancestry(ancestry: &Ancestry) -> Vec<usize> {
-    let mut ordered_ancestry: Ancestry = ancestry.clone();
-    order_cherries(&mut ordered_ancestry);
+    let mut cherries = ancestry.clone();
 
-    build_vector(&ordered_ancestry)
+    let row_idxs: Vec<usize> = (0..ancestry.len()).collect();
+    build_cherries(&mut cherries, &row_idxs);
+
+    build_vector(&cherries)
 }
 
 pub fn get_edges_from_pairs(pairs: &Pairs) -> Vec<(usize, usize)> {
@@ -214,29 +217,10 @@ pub fn find_coords_of_first_leaf(ancestry: &Ancestry, leaf: usize) -> (usize, us
     panic!("Leaf not found in ancestry");
 }
 
-/// Order cherries in an ancestry vector.
-/// The goal of this function is to find indices for an argsort to sort the cherries
-/// We utilise the parent nodes to sort the cherries.
-/// Returns two vectors:
-/// 1. `row_idxs`: the indices of the sorted cherries
-/// 2. `bl_rows_to_swap`: the indices of the cherries that need to swap their branch lengths
-///    The latter is important to ensure bijectivity of the matrix object.
-pub fn order_cherries(ancestry: &mut Ancestry) -> (Vec<usize>, Vec<usize>) {
+fn build_cherries(ancestry: &mut Ancestry, row_idxs: &[usize]) -> Vec<usize> {
     let num_cherries = ancestry.len();
     let num_nodes = 2 * num_cherries + 2;
-
     let mut min_desc = vec![usize::MAX; num_nodes];
-
-    let mut row_idxs: Vec<usize> = (0..num_cherries).collect();
-    row_idxs.sort_by_key(|&i| ancestry[i][2]);
-
-    // Sort by the parent node (ascending order)
-    let mut new_ancestry: Ancestry = Vec::with_capacity(num_cherries);
-    for i in &row_idxs {
-        new_ancestry.push(ancestry[*i]);
-    }
-    *ancestry = new_ancestry;
-
     let mut bl_rows_to_swap: Vec<usize> = Vec::with_capacity(num_cherries);
 
     for (i, cherry) in ancestry.iter_mut().enumerate() {
@@ -272,6 +256,31 @@ pub fn order_cherries(ancestry: &mut Ancestry) -> (Vec<usize>, Vec<usize>) {
         // Allocate the largest descendant as the "parent"
         *cherry = [min_desc1, min_desc2, desc_max];
     }
+
+    bl_rows_to_swap
+}
+
+/// Order cherries in an ancestry vector.
+/// The goal of this function is to find indices for an argsort to sort the cherries
+/// We utilise the parent nodes to sort the cherries.
+/// Returns two vectors:
+/// 1. `row_idxs`: the indices of the sorted cherries
+/// 2. `bl_rows_to_swap`: the indices of the cherries that need to swap their branch lengths
+///    The latter is important to ensure bijectivity of the matrix object.
+pub fn order_cherries(ancestry: &mut Ancestry) -> (Vec<usize>, Vec<usize>) {
+    let num_cherries = ancestry.len();
+
+    let mut row_idxs: Vec<usize> = (0..num_cherries).collect();
+    row_idxs.sort_by_key(|&i| ancestry[i][2]);
+
+    // Sort by the parent node (ascending order)
+    let mut new_ancestry: Ancestry = Vec::with_capacity(num_cherries);
+    for i in &row_idxs {
+        new_ancestry.push(ancestry[*i]);
+    }
+    *ancestry = new_ancestry;
+
+    let bl_rows_to_swap = build_cherries(ancestry, &row_idxs);
 
     (row_idxs, bl_rows_to_swap)
 }
@@ -606,7 +615,7 @@ pub fn get_common_ancestor(v: &[usize], node1: usize, node2: usize) -> usize {
 /// // Tree with 7 leaves
 /// let v = vec![0, 0, 0, 2, 5, 3];
 /// let (v_qs, label_mapping) = queue_shuffle(&v, false);
-/// assert_eq!(v_qs, vec![0, 0, 0, 2, 3, 2]);
+/// assert_eq!(v_qs, vec![0, 1, 1, 2, 3, 2]);
 /// // Suppose that you originally have a list of string labels for taxa
 /// // Initially, represent the n-th taxon by an integer leaf n
 /// // In this scenario,
@@ -614,7 +623,7 @@ pub fn get_common_ancestor(v: &[usize], node1: usize, node2: usize) -> usize {
 /// // The 5th taxon is now represented by 6
 /// // The 6th taxon is now represented by 4
 /// // The 7th taxon is now represented by 5
-/// assert_eq!(label_mapping, vec![0, 1, 2, 3, 6, 4, 5]);
+/// assert_eq!(label_mapping, vec![1, 5, 6, 4, 0, 2, 3]);
 /// ```
 pub fn queue_shuffle(v: &[usize], shuffle_cherries: bool) -> (Vec<usize>, Vec<usize>) {
     let pairs = get_pairs(v);
@@ -628,11 +637,14 @@ pub fn queue_shuffle(v: &[usize], shuffle_cherries: bool) -> (Vec<usize>, Vec<us
     //
     let mut queue = vec![2 * k];
     let mut j = 0;
+    let mut new_pairs: Pairs = Vec::new();
 
-    // Stop when we have k internal nodes in the queue
-    // For a tree with k + 1 leaves, we need k internal nodes
-    while queue.len() < k {
-        let [c1, c2, _] = ancestry[queue[j] - n_leaves];
+    let mut label_mapping: Vec<usize> = (0..n_leaves).collect();
+
+    let mut node_code = Vec::new();
+
+    while new_pairs.len() < k {
+        let [c2, c1, _] = ancestry[queue[j] - n_leaves];
 
         // `shuffle_cherries` allows to randomly permutate the order of children
         let child_order = if shuffle_cherries && rand::random() {
@@ -641,50 +653,50 @@ pub fn queue_shuffle(v: &[usize], shuffle_cherries: bool) -> (Vec<usize>, Vec<us
             [c1, c2]
         };
 
+        let next_leaf = j + 1;
+
+        let new_pair = if node_code.is_empty() {
+            (0, 1)
+        } else {
+            (node_code[j - 1], next_leaf)
+        };
+
+        new_pairs.push(new_pair);
+
         // Add internal nodes to the queue
-        for &c in &child_order {
+        for (i, &c) in child_order.iter().enumerate() {
             if c >= n_leaves {
                 queue.push(c);
+                if i == 0 {
+                    node_code.push(new_pair.0)
+                } else {
+                    node_code.push(new_pair.1);
+                }
             }
         }
 
-        // j helps visiting the next element in the queue first
-        // (i.e., internal nodes under queue[j])
+        if child_order[1] < n_leaves {
+            label_mapping[new_pair.1] = c2;
+        }
+        if child_order[0] < n_leaves {
+            label_mapping[new_pair.0] = c1;
+        }
+
         j += 1;
     }
 
-    //
-    // Stage 2: Re-order the pairs according to the queue
-    //
-    let mut new_pairs: Pairs = Vec::with_capacity(k);
-
-    // Mapping of original leaves to new leaves
-    // Index = original leaf
-    // Value = new leaf index
-    let mut label_mapping: Vec<usize> = (0..n_leaves).collect();
-
-    // Process the queue in reverse order
-    for i in 0..k {
-        // Next pair according to the queue
-        let (c1, c2) = pairs[queue[i] - k - 1];
-
-        let next_leaf = i + 1;
-
-        // If c2 is not the next leaf, it does not
-        // respect the constraint of an ordered tree
-        // So we swap the labels c2 and next_leaf
-        if c2 != next_leaf {
-            label_mapping[c2] = next_leaf;
-        }
-
-        // Push an ordered pair
-        new_pairs.push((label_mapping[c1], next_leaf));
-    }
-
-    // Pairs were created in reverse order, so we reverse them
     new_pairs.reverse();
 
-    let v_new = from_pairs(&new_pairs);
+    let v_qs = from_pairs(&new_pairs);
 
-    (v_new, label_mapping)
+    {
+        let unique: HashSet<_> = label_mapping.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            label_mapping.len(),
+            "label_mapping elements must be unique"
+        );
+    }
+
+    (v_qs, label_mapping)
 }

--- a/py-phylo2vec/phylo2vec/utils/vector.py
+++ b/py-phylo2vec/phylo2vec/utils/vector.py
@@ -104,6 +104,50 @@ def queue_shuffle(v, shuffle_cherries=False) -> Tuple[np.ndarray, List[int]]:
     while also ensuring a smooth path through the space of orderings
 
     For more details, see https://doi.org/10.1093/gbe/evad213
+    Illustration of the algorithm:
+                    ////-3
+                ////6|
+        ////7|      \\\\-2
+        |     |
+    -8|      \\\\-1
+        |
+        |      ////-4
+        \\\\5|
+                \\\\-0
+
+    The ancestry array of this tree is:
+    [8, 7, 5]
+    [7, 6, 1]
+    [6, 3, 2]
+    [5, 4, 0]
+
+    Unrolled, it becomes:
+    8 7 5 6 1 3 2 4 0
+
+    We encode the nodes as it:
+    Start by encoding the first two non-root nodes as 0, 1
+    For the next pairs:
+        * The left member takes the label was the previous parent node
+        * The right member increments the previous right member by 1
+
+    Ex:
+    8 7 5 6 1 3 2 4 0
+        0 1 0 2
+
+    then
+
+    8 7 5 6 1 3 2 4 0
+        0 1 0 2 1 3
+
+    then
+
+    8 7 5 6 1 3 2 4 0
+        0 1 0 2 1 3 0 4
+
+    The code for the leaf nodes (0, 1, 2, 3, 4) is their new label
+
+    Note that the full algorithm also features a queue of internal nodes
+    which could switch the processing order of rows in the ancestry array.
 
     Parameters
     ----------

--- a/py-phylo2vec/phylo2vec/utils/vector.py
+++ b/py-phylo2vec/phylo2vec/utils/vector.py
@@ -170,7 +170,7 @@ def reorder_v(reorder_method, v_old, label_mapping_old, shuffle_cols=False):
         v_new, vec_mapping = queue_shuffle(v_old, shuffle_cherries=shuffle_cols)
         # For compatibility with the old label mapping (for _hc)
         label_mapping_new = {
-            vec_mapping[i]: label_mapping_old[i] for i in range(len(vec_mapping))
+            i: label_mapping_old[idx] for i, idx in enumerate(vec_mapping)
         }
     elif reorder_method == "bfs":
         raise ValueError(

--- a/py-phylo2vec/tests/test_reorder.py
+++ b/py-phylo2vec/tests/test_reorder.py
@@ -1,18 +1,25 @@
 """Temporary test of reordering functions against legacy algorithms (v0.x)"""
 
 import random
+import string
+
+from itertools import product
 
 import numpy as np
 import pytest
 
+from ete3 import Tree
+
 from phylo2vec.base.ancestry import from_ancestry, to_ancestry
-from phylo2vec.utils.vector import sample_vector
-from phylo2vec import _phylo2vec_core as core
+from phylo2vec.base.newick import to_newick
+from phylo2vec.base.pairs import from_pairs
+from phylo2vec.utils.newick import apply_label_mapping
+from phylo2vec.utils.vector import queue_shuffle, sample_vector
 from .config import MIN_N_LEAVES, MAX_N_LEAVES, N_REPEATS
 
 
 def legacy_queue_shuffle(
-    ancestry_old, label_mapping_old, reorder_internal=True, shuffle_cols=False
+    ancestry_old, label_mapping_old, reorder_internal=False, shuffle_cols=False
 ):
     """
     Legacy version of the queue shuffle algorithm (called _reorder_birth_death in v0.x)
@@ -79,39 +86,58 @@ def legacy_queue_shuffle(
             ancestry_old[row, :2] = ancestry_old[row, :2][::col_order]
             next_pair = next_pair[::col_order]
 
-        for i, child in enumerate(ancestry_old[row, :2]):
+        for i, child in enumerate(ancestry_old[row, 1:]):
             if child < len(ancestry_old) + 1:
                 label_mapping_new[next_pair[i]] = label_mapping_old[child]
 
-                ancestry_new[row, i] = next_pair[i]
+                ancestry_new[row, i + 1] = next_pair[i]
 
             # Not a leaf node --> add it to the visit list
             else:
                 visited_internals.append(child)
                 if reorder_internal:
                     # Basically, flip the nodes
-                    # Ex: relabel 7 in M_old as 9 in M_new
-                    # Then relabel 9 in M_old as 7 in M_new
+                    # Ex: relabel 7 in M_old as 9 in ancestry_new
+                    # Then relabel 9 in M_old as 7 in ancestry_new
                     internal_node = internal_labels.pop()
-                    ancestry_new[row, i] = internal_node
-                    ancestry_new[2 * len(ancestry_new) - ancestry_old[row, i], 2] = (
-                        ancestry_new[row, i]
-                    )
+                    ancestry_new[row, i + 1] = internal_node
+                    ancestry_new[
+                        2 * len(ancestry_new) - ancestry_old[row, i + 1], 0
+                    ] = ancestry_new[row, i + 1]
 
                 to_visit.append(child)
 
-        visited.extend(ancestry_old[row, :2])
-
+        visited.extend(ancestry_old[row, 1:])
         node_code.extend(next_pair)
         visits += 1
 
     # Re-sort M such that the root node R is the first row, then internal nodes R-1, R-2, ...
-    ancestry_new = ancestry_new[ancestry_new[:, 2].argsort()[::-1]]
+    ancestry_new = ancestry_new[ancestry_new[:, 0].argsort()[::-1]]
 
-    return ancestry_new, label_mapping_new
+    return np.flip(ancestry_new), label_mapping_new, node_code
 
 
-@pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES + 1))
+# def to_pairs(ancestry):
+#     num_cherries = ancestry.shape[0]
+#     ancestry = ancestry[np.argsort(ancestry[:, 2])]
+#     num_nodes = 2 * num_cherries + 2
+#     MAX = np.iinfo(np.int32).max
+#     min_desc = np.ones(num_nodes, dtype=np.int32) * MAX
+#     pairs = []
+
+#     for i, cherry in enumerate(ancestry):
+#         c1, c2, p = cherry
+
+#         min_desc1 = min_desc[c1] if min_desc[c1] != MAX else c1
+#         min_desc2 = min_desc[c2] if min_desc[c2] != MAX else c2
+
+#         desc_min, _ = sorted([min_desc1, min_desc2])
+#         min_desc[p] = desc_min
+#         pairs.append((int(min_desc1), int(min_desc2)))
+#     return pairs
+
+
+@pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES))
 def test_queue_shuffle(n_leaves):
     """Test the legacy queue shuffle algorithm
 
@@ -123,32 +149,32 @@ def test_queue_shuffle(n_leaves):
     for _ in range(N_REPEATS):
         # Sample a vector and convert it to an ancestry matrix
         v = sample_vector(n_leaves)
+
+        taxa = product(string.ascii_lowercase, repeat=2)
+        dict_mapping_old = {i: "".join(next(taxa)) for i in range(n_leaves)}
+
         ancestry_old = to_ancestry(v)
-
-        dict_mapping_old = {i: f"{i}" for i in range(n_leaves)}
-
-        ancestry_new, dict_mapping_py = legacy_queue_shuffle(
-            np.flip(ancestry_old, axis=0), dict_mapping_old
+        # the output ancestry is difficult to use without adding more dependencies
+        # as it doesn't respect the ordering of internal nodes in an ancestry matrix
+        # best solution it to use the `node code`, which was a precursor of the pair format
+        _, dict_mapping_py, node_code = legacy_queue_shuffle(
+            np.flip(ancestry_old), dict_mapping_old
         )
+        pairs_new = [
+            (node_code[i], node_code[i + 1]) for i in range(0, len(node_code), 2)
+        ][::-1]
 
         # Convert back to vector and check if it matches the original vector
-        v_new_legacy = from_ancestry(ancestry_new)
 
-        v_new_rust, vec_mapping_rust = core.queue_shuffle(v, False)
+        v_new_legacy = from_pairs(pairs_new)
+
+        v_new_rust, vec_mapping_rust = queue_shuffle(v, shuffle_cherries=False)
 
         assert np.array_equal(v_new_legacy, v_new_rust)
 
-        inv_dict_mapping_py = {int(val): key for key, val in dict_mapping_py.items()}
-
-        # Convert the python dict_mapping to a list
-        vec_mapping_py = [int(inv_dict_mapping_py.get(i, i)) for i in range(n_leaves)]
-
-        assert vec_mapping_py == vec_mapping_rust
-
         # Convert the rust list to a dict
         dict_mapping_rust = {
-            vec_mapping_rust[i]: dict_mapping_old[i]
-            for i in range(len(vec_mapping_rust))
+            i: dict_mapping_old[idx] for i, idx in enumerate(vec_mapping_rust)
         }
 
         assert dict_mapping_py == dict_mapping_rust


### PR DESCRIPTION
This makes `queue shuffle` work exactly as previous implementations ([GradME](https://github.com/Neclow/GradME) and [preprint](https://github.com/Neclow/phylo2vec_preprint)). Added some more documentation in the core function and the test to reflect those changes, with examples of how the algorithm works.

The change also removes cherry ordering from `from_ancestry` and `from_pairs` to avoid uninteded side effects