### PR TITLE
refactor: handle n_leaves edge cases for sampling

### DIFF
--- a/py-phylo2vec/phylo2vec/utils/matrix.py
+++ b/py-phylo2vec/phylo2vec/utils/matrix.py
@@ -24,7 +24,7 @@ def sample_matrix(n_leaves: int, ordered: bool = False) -> np.ndarray:
     Parameters
     ----------
     n_leaves : int
-        Number of leaves
+        Number of leaves (>= 2)
     ordered : bool, optional
         If True, sample an ordered tree, by default False
 

--- a/py-phylo2vec/phylo2vec/utils/vector.py
+++ b/py-phylo2vec/phylo2vec/utils/vector.py
@@ -32,7 +32,7 @@ def sample_vector(n_leaves: int, ordered: bool = False) -> np.ndarray:
     Parameters
     ----------
     n_leaves : int
-        Number of leaves
+        Number of leaves (>= 2)
     ordered : bool, optional
         If True, sample an ordered tree, by default False
 

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray2};
-use pyo3::exceptions::PyAssertionError;
+use pyo3::exceptions::{PyAssertionError, PyValueError};
 use pyo3::prelude::*;
 
 use phylo2vec::matrix::base as mbase;
@@ -15,13 +15,25 @@ use phylo2vec::vector::graph as vgraph;
 use phylo2vec::vector::ops as vops;
 
 #[pyfunction]
-fn sample_vector(n_leaves: usize, ordered: bool) -> Vec<usize> {
-    vbase::sample_vector(n_leaves, ordered)
+fn sample_vector(n_leaves: isize, ordered: bool) -> PyResult<Vec<usize>> {
+    if n_leaves < 2 {
+        Err(PyValueError::new_err("n_leaves must be at least 2"))
+    } else {
+        Ok(vbase::sample_vector(n_leaves as usize, ordered))
+    }
 }
 
 #[pyfunction]
-fn sample_matrix(py: Python<'_>, n_leaves: usize, ordered: bool) -> Bound<'_, PyArray2<f64>> {
-    mbase::sample_matrix(n_leaves, ordered).into_pyarray(py)
+fn sample_matrix(
+    py: Python<'_>,
+    n_leaves: isize,
+    ordered: bool,
+) -> PyResult<Bound<'_, PyArray2<f64>>> {
+    if n_leaves < 2 {
+        Err(PyValueError::new_err("n_leaves must be at least 2"))
+    } else {
+        Ok(mbase::sample_matrix(n_leaves as usize, ordered).into_pyarray(py))
+    }
 }
 
 #[pyfunction]

--- a/py-phylo2vec/tests/test_utils.py
+++ b/py-phylo2vec/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 from ete3 import Tree
 
 from phylo2vec.base.newick import to_newick
+from phylo2vec.utils.matrix import check_matrix, sample_matrix
 from phylo2vec.utils.vector import (
     add_leaf,
     check_vector,
@@ -25,8 +26,8 @@ from .config import MAX_N_LEAVES, MIN_N_LEAVES, N_REPEATS
 
 
 @pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES + 1))
-def test_sample(n_leaves):
-    """Test the sample function
+def test_sample_vector(n_leaves):
+    """Test the sample_vector function
 
     Parameters
     ----------
@@ -36,6 +37,37 @@ def test_sample(n_leaves):
     for _ in range(N_REPEATS):
         v = sample_vector(n_leaves)
         check_vector(v)  # Asserts that v is valid
+
+
+class TestSampleVectorEdgeCases:
+    def test_sample_vector_negative(self):
+        """Test the sample_vector function with negative n_leaves"""
+        with pytest.raises(ValueError):
+            sample_vector(-1)
+
+    def test_sample_vector_zero(self):
+        """Test the sample_vector function with zero leaves"""
+        with pytest.raises(ValueError):
+            sample_vector(0)
+
+    def test_sample_vector_two(self):
+        """Test the sample_vector function with two leaves"""
+        v = sample_vector(2)
+        check_vector(v)  # Asserts that v is valid
+
+
+@pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES + 1))
+def test_sample_matrix(n_leaves):
+    """Test the sample_vector function
+
+    Parameters
+    ----------
+    n_leaves : int
+        Number of leaves
+    """
+    for _ in range(N_REPEATS):
+        m = sample_matrix(n_leaves)
+        check_matrix(m)  # Asserts that m is valid
 
 
 @pytest.mark.parametrize("n_leaves", range(MIN_N_LEAVES, MAX_N_LEAVES + 1))

--- a/r-phylo2vec/src/rust/src/lib.rs
+++ b/r-phylo2vec/src/rust/src/lib.rs
@@ -45,18 +45,27 @@ fn convert_from_rmatrix(matrix: &Robj) -> Result<Array2<f64>, &'static str> {
 /// Sample a random tree topology via Phylo2Vec
 /// @export
 #[extendr]
-fn sample_vector(n_leaves: usize, ordered: bool) -> Vec<i32> {
-    let v = vbase::sample_vector(n_leaves, ordered);
-    as_i32(v)
+fn sample_vector(n_leaves: isize, ordered: bool) -> Result<Vec<i32>, Error> {
+    if n_leaves < 2 {
+        Err(Error::OutOfRange("n_leaves must be at least 2".into()))
+    } else {
+        Ok(as_i32(vbase::sample_vector(n_leaves as usize, ordered)))
+    }
 }
 
 /// Sample a random tree with branch lengths via Phylo2Vec
 /// @export
 #[extendr]
-fn sample_matrix(n_leaves: usize, ordered: bool) -> RMatrix<f64> {
-    let matrix = mbase::sample_matrix(n_leaves, ordered);
-    let shape = matrix.shape();
-    RMatrix::new_matrix(shape[0], shape[1], |r, c| matrix[[r, c]])
+fn sample_matrix(n_leaves: isize, ordered: bool) -> Result<RMatrix<f64>, Error> {
+    if n_leaves < 2 {
+        Err(Error::OutOfRange("n_leaves must be at least 2".into()))
+    } else {
+        let matrix = mbase::sample_matrix(n_leaves as usize, ordered);
+        let shape = matrix.shape();
+        Ok(RMatrix::new_matrix(shape[0], shape[1], |r, c| {
+            matrix[[r, c]]
+        }))
+    }
 }
 
 /// Recover a rooted tree (in Newick format) from a Phylo2Vec vector


### PR DESCRIPTION
Handle a few edge cases on vector/matrix sampling. Noticed that in Python, when entering n_leaves = -x would create underflowe errors, while entering n_leaves = 0 would hang (presumably because n_leaves - 1 would flip to usize::MAX). So I added a condition to handle and throw errors if n_leaves <= 2 in the python and R lib.rs

Added tests for sample_matrix in python.