### PR TITLE
Unrooted coph

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,27 @@ hc = HillClimbing(verbose=True)
 hc_result = hc.fit("/path/to/your_fasta_file.fa")
 ```
 
+#### Command-line interface (CLI)
+
+We also provide a command-line interface for quick experimentation on phylo2vec-derived objects.
+
+To see the available functions, run:
+
+```bash
+phylo2vec --help
+```
+
+Examples:
+
+```bash
+phylo2vec samplev 5 # Sample a vector with 5 leaves
+phylo2vec samplem 5 # Sample a matrix with 5 leaves
+phylo2vec from_newick '((0,1),2);' # Convert a Newick to a vector
+phylo2vec from_newick '((0:0.3,1:0.1):0.5,2:0.4);' # Convert a Newick to a matrix
+phylo2vec to_newick 0,1,2 # Convert a vector to Newick
+phylo2vec to_newick $'0.0,1.0,2.0\n0.0,3.0,4.0' # Convert a matrix to Newick
+```
+
 ## Documentation
 
 For comprehensive documentation, tutorials, and API reference, visit:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ hc_result = hc.fit("/path/to/your_fasta_file.fa")
 
 #### Command-line interface (CLI)
 
-We also provide a command-line interface for quick experimentation on phylo2vec-derived objects.
+We also provide a command-line interface for quick experimentation on
+phylo2vec-derived objects.
 
 To see the available functions, run:
 

--- a/py-phylo2vec/phylo2vec/cli.py
+++ b/py-phylo2vec/phylo2vec/cli.py
@@ -1,0 +1,140 @@
+"""
+Command line interface for Phylo2Vec.
+
+Examples:
+phylo2vec samplev 5 # Sample a vector with 5 leaves
+phylo2vec samplem 5 # Sample a matrix with 5 leaves
+phylo2vec from_newick '((0,1),2);' # Convert a Newick to a vector
+phylo2vec from_newick '((0:0.3,1:0.1):0.5,2:0.4);' # Convert a Newick to a matrix
+phylo2vec to_newick 0,1,2 # Convert a vector to Newick
+phylo2vec to_newick $'0.0,1.0,2.0\n0.0,3.0,4.0' # Convert a matrix to Newick
+"""
+
+import sys
+
+from argparse import ArgumentParser
+
+from phylo2vec.base.newick import from_newick, to_newick
+from phylo2vec.utils.matrix import sample_matrix
+from phylo2vec.utils.vector import sample_vector
+from phylo2vec.io.reader import read
+from phylo2vec.io.writer import write
+
+
+COMMANDS = {
+    "samplev": {
+        "help": "Sample a Phylo2Vec vector.",
+        "func": sample_vector,
+        "args": {
+            "n_leaves": {
+                "type": int,
+                "help": "Number of leaves in the vector",
+            },
+            "--ordered": {
+                "action": "store_true",
+                "help": "Sample an ordered vector",
+            },
+        },
+        "type": "write",
+    },
+    "samplem": {
+        "help": "Sample a Phylo2Vec matrix.",
+        "func": sample_matrix,
+        "args": {
+            "n_leaves": {
+                "type": int,
+                "help": "Number of leaves in the matrix",
+            },
+            "--ordered": {
+                "action": "store_true",
+                "help": "Sample an ordered matrix",
+            },
+        },
+        "type": "write",
+    },
+    "from_newick": {
+        "help": "Convert a Newick string to a Phylo2Vec vector/matrix.",
+        "func": from_newick,
+        "args": {
+            "newick": {
+                "type": str,
+                "help": "Newick string representing the tree",
+            },
+        },
+        "type": "write",
+    },
+    "to_newick": {
+        "help": "Convert a Phylo2Vec vector/matrix to a Newick string.",
+        "func": to_newick,
+        "args": {
+            "vector_or_matrix": {
+                "type": str,
+                "help": "Phylo2Vec vector/matrix to convert",
+            },
+        },
+        "type": "read",
+    },
+}
+
+
+def parse_args():
+    """Phylo2vec argument parser.
+
+    Sets up the command line interface for the Phylo2Vec CLI.
+
+    Returns
+    -------
+    argparse.Namespace
+        The parsed command line arguments.
+    """
+    global_parser = ArgumentParser(
+        description="phylo2vec: a library for vector-based phylogenetic tree manipulation"
+    )
+
+    subparsers = global_parser.add_subparsers(title="subcommands")
+
+    for command, details in COMMANDS.items():
+        parser = subparsers.add_parser(command, help=details["help"])
+
+        for arg_name, arg_details in details["args"].items():
+            parser.add_argument(
+                arg_name,
+                **arg_details,
+            )
+
+    return global_parser.parse_args()
+
+
+def main():
+    """Main module"""
+
+    args = parse_args()
+
+    command_name = sys.argv[1] if len(sys.argv) > 1 else None
+
+    if command_name is None:
+        print("No command provided. Use --help for more information.")
+        sys.exit(1)
+    elif command_name not in COMMANDS:
+        print(f"Unknown command: {command_name}. Use --help for more information.")
+        sys.exit(1)
+    else:
+        command = COMMANDS[command_name]
+        func = command["func"]
+        the_args = vars(args)
+
+        # Process input
+        if command["type"] == "read":
+            the_args["vector_or_matrix"] = read(the_args["vector_or_matrix"])
+
+        out = func(**the_args)
+
+        # Process output
+        if command["type"] == "write":
+            out = write(out)
+
+        print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/py-phylo2vec/phylo2vec/io/reader.py
+++ b/py-phylo2vec/phylo2vec/io/reader.py
@@ -2,6 +2,9 @@
 
 import os
 
+from io import StringIO, TextIOBase
+from typing import Union
+
 import numpy as np
 
 from phylo2vec.base.newick import from_newick
@@ -10,13 +13,19 @@ from phylo2vec.utils.vector import check_vector
 from ._validation import check_path
 
 
-def load(filepath: str, delimiter: str = ",") -> np.ndarray:
+def read(buffer: str, delimiter: str = ",") -> np.ndarray:
+    return load(StringIO(buffer), delimiter=delimiter)
+
+
+def load(
+    filepath_or_buffer: Union[str, TextIOBase], delimiter: str = ","
+) -> np.ndarray:
     """Read a text/csv file into a Phylo2Vec vector or matrix.
 
     Parameters
     ----------
-    filepath : str or file-like object
-        File path to read
+    filepath : str, path object or file-like object
+        File path to read or StringIO object containing the data.
     delimiter : str, optional
         Character used to separate values, by default ","
 
@@ -26,12 +35,15 @@ def load(filepath: str, delimiter: str = ",") -> np.ndarray:
         A vector (ndim == 1) or matrix (ndim == 2)
         which satisfies Phylo2Vec constraints
     """
-    check_path(filepath, "array")
+    if not hasattr(filepath_or_buffer, "read"):
+        if not os.path.isfile(filepath_or_buffer):
+            raise FileNotFoundError(f"File not found: {filepath_or_buffer}")
+        check_path(filepath_or_buffer, "array")
     # np.genfromtxt with dtype = None will infer the type
     # Using should solve the edge case:
     # load a matrix with 2 leaves ([[0, bl1, bl2]] = float)
     # vs. a vector with 4 leaves ([0, v1, v2] = int)
-    arr = np.genfromtxt(filepath, delimiter=delimiter, dtype=None)
+    arr = np.genfromtxt(filepath_or_buffer, delimiter=delimiter, dtype=None)
 
     if arr.ndim == 1 and np.issubdtype(arr.dtype, np.integer):
         check_vector(arr)

--- a/py-phylo2vec/phylo2vec/io/writer.py
+++ b/py-phylo2vec/phylo2vec/io/writer.py
@@ -1,5 +1,6 @@
 """Methods to write Phylo2Vec vectors/matrices."""
 
+from io import StringIO
 from typing import Dict, Optional
 
 import numpy as np
@@ -7,6 +8,20 @@ import numpy as np
 from phylo2vec.base.newick import to_newick
 from phylo2vec.utils.newick import apply_label_mapping
 from ._validation import check_path
+
+
+def write(vector_or_matrix: np.ndarray, delimiter: str = ",") -> str:
+    if vector_or_matrix.ndim == 2:
+        buffer = StringIO()
+        np.savetxt(buffer, vector_or_matrix, delimiter=delimiter)
+        return buffer.getvalue()
+
+    if vector_or_matrix.ndim == 1:
+        return np.array2string(vector_or_matrix, separator=delimiter)[1:-1]
+
+    raise ValueError(
+        "vector_or_matrix should either be a vector (ndim == 1) or matrix (ndim == 2)"
+    )
 
 
 def save(vector_or_matrix: np.ndarray, filepath: str, delimiter: str = ",") -> None:

--- a/py-phylo2vec/phylo2vec/stats/nodewise.py
+++ b/py-phylo2vec/phylo2vec/stats/nodewise.py
@@ -23,20 +23,10 @@ def cophenetic_distances(vector_or_matrix, unrooted=False):
     numpy.ndarray
         Cophenetic distance matrix
     """
-    if unrooted:
-        warnings.warn(
-            (
-                "Argument `unrooted` is ignored. It is deprecated and "
-                "will be removed in future versions. When ensuring "
-                "compatibility with `ape` and `ete` (mode='keep'), the "
-                "argument becomes unnecessary. "
-            ),
-            FutureWarning,
-        )
     if vector_or_matrix.ndim == 2:
-        coph = core.cophenetic_distances_with_bls(vector_or_matrix)
+        coph = core.cophenetic_distances_with_bls(vector_or_matrix, unrooted=unrooted)
     elif vector_or_matrix.ndim == 1:
-        coph = core.cophenetic_distances(vector_or_matrix)
+        coph = core.cophenetic_distances(vector_or_matrix, unrooted=unrooted)
     else:
         raise ValueError(
             "vector_or_matrix should either be a vector (ndim == 1) or matrix (ndim == 2)"

--- a/py-phylo2vec/pyproject.toml
+++ b/py-phylo2vec/pyproject.toml
@@ -41,6 +41,9 @@ opt = [
     "tqdm"
 ]
 
+[project.scripts]
+phylo2vec = "phylo2vec.cli:main"
+
 [tool.maturin]
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 features = ["pyo3/extension-module"]

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -138,17 +138,22 @@ fn build_newick(input_pairs: Vec<(usize, usize)>) -> String {
 }
 
 #[pyfunction]
-fn cophenetic_distances(py: Python<'_>, input_vector: Vec<usize>) -> Bound<'_, PyArray2<f64>> {
-    vgraph::cophenetic_distances(&input_vector).into_pyarray(py)
+fn cophenetic_distances(
+    py: Python<'_>,
+    input_vector: Vec<usize>,
+    unrooted: bool,
+) -> Bound<'_, PyArray2<f64>> {
+    vgraph::cophenetic_distances(&input_vector, unrooted).into_pyarray(py)
 }
 
 #[pyfunction]
 fn cophenetic_distances_with_bls<'py>(
     py: Python<'py>,
     input_matrix: PyReadonlyArray2<f64>,
+    unrooted: bool,
 ) -> Bound<'py, PyArray2<f64>> {
     let m = input_matrix.as_array();
-    mgraph::cophenetic_distances(&m).into_pyarray(py)
+    mgraph::cophenetic_distances(&m, unrooted).into_pyarray(py)
 }
 
 #[pyfunction]

--- a/py-phylo2vec/tests/test_cli.py
+++ b/py-phylo2vec/tests/test_cli.py
@@ -1,0 +1,281 @@
+import os
+import sys
+
+from io import StringIO
+
+import numpy as np
+import pytest
+
+from unittest.mock import patch
+
+from phylo2vec.cli import parse_args, main
+
+
+class TestHelp:
+    """Test help functionality."""
+
+    def test_main_help(self):
+        """Test main help message displays correctly."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "--help"]):
+                parse_args()
+        # Help should exit with code 0
+        assert exc_info.value.code == 0
+
+    def test_subcommand_help_samplev(self):
+        """Test samplev subcommand help."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "samplev", "--help"]):
+                parse_args()
+        assert exc_info.value.code == 0
+
+    def test_subcommand_help_samplem(self):
+        """Test samplem subcommand help."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "samplem", "--help"]):
+                parse_args()
+        assert exc_info.value.code == 0
+
+    def test_subcommand_help_from_newick(self):
+        """Test from_newick subcommand help."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "from_newick", "--help"]):
+                parse_args()
+        assert exc_info.value.code == 0
+
+    def test_subcommand_help_to_newick(self):
+        """Test to_newick subcommand help."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "to_newick", "--help"]):
+                parse_args()
+        assert exc_info.value.code == 0
+
+
+class TestSampleV:
+    """Test the samplev command."""
+
+    def test_valid_number(self):
+        """Test samplev with valid number of leaves."""
+        with patch("sys.argv", ["phylo2vec", "samplev", "5"]):
+            args = parse_args()
+            assert hasattr(args, "n_leaves")
+            assert args.n_leaves == 5
+            assert hasattr(args, "ordered")
+            assert not args.ordered
+
+    def test_with_ordered_flag(self):
+        """Test samplev with --ordered flag."""
+        with patch("sys.argv", ["phylo2vec", "samplev", "3", "--ordered"]):
+            args = parse_args()
+            assert args.n_leaves == 3
+            assert args.ordered
+
+    def test_missing_argument(self):
+        """Test samplev without required n_leaves argument."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "samplev"]):
+                parse_args()
+        assert exc_info.value.code != 0
+
+    def test_string(self):
+        """Test samplev with non-numeric string should fail."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.stderr", new_callable=StringIO):  # Suppress error output
+                with patch("sys.argv", ["phylo2vec", "samplev", "not_a_number"]):
+                    parse_args()
+        # Should exit with error code (error 2 for argument errors)
+        assert exc_info.value.code == 2
+
+    def test_float(self):
+        """Test samplev with float number should fail."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "samplev", "3.5"]):
+                parse_args()
+        # Should exit with error code (error 2 for argument errors)
+        assert exc_info.value.code == 2
+
+    def test_negative_number(self):
+        """Test samplev with negative number should fail."""
+        with patch("sys.argv", ["phylo2vec", "samplev", "-5"]):
+            with pytest.raises(ValueError):
+                main()
+
+    def test_zero(self):
+        """Test samplev with negative number should fail."""
+        with patch("sys.argv", ["phylo2vec", "samplev", "0"]):
+            with pytest.raises(ValueError):
+                main()
+
+    def test_big_number(self):
+        """Test samplev with a large number."""
+        with patch("sys.argv", ["phylo2vec", "samplev", f"{1000000}"]):
+            main()
+
+
+class TestSampleM:
+    """Test the samplem command."""
+
+    def test_valid_number(self):
+        """Test samplem with valid number of leaves."""
+        with patch("sys.argv", ["phylo2vec", "samplem", "5"]):
+            args = parse_args()
+            assert hasattr(args, "n_leaves")
+            assert args.n_leaves == 5
+            assert hasattr(args, "ordered")
+            assert not args.ordered
+
+    def test_with_ordered_flag(self):
+        """Test samplem with --ordered flag."""
+        with patch("sys.argv", ["phylo2vec", "samplem", "3", "--ordered"]):
+            args = parse_args()
+            assert args.n_leaves == 3
+            assert args.ordered
+
+    def test_missing_argument(self):
+        """Test samplem without required n_leaves argument."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "samplem"]):
+                parse_args()
+        assert exc_info.value.code != 0
+
+    def test_string(self):
+        """Test samplem with non-numeric string should fail."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.stderr", new_callable=StringIO):  # Suppress error output
+                with patch("sys.argv", ["phylo2vec", "samplem", "not_a_number"]):
+                    parse_args()
+        # Should exit with error code (error 2 for argument errors)
+        assert exc_info.value.code == 2
+
+    def test_float(self):
+        """Test samplem with float number should fail."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.argv", ["phylo2vec", "samplem", "3.5"]):
+                parse_args()
+        # Should exit with error code (error 2 for argument errors)
+        assert exc_info.value.code == 2
+
+    def test_negative_number(self):
+        """Test samplem with negative number should fail."""
+        with patch("sys.argv", ["phylo2vec", "samplem", "-5"]):
+            with pytest.raises(ValueError):
+                main()
+
+    def test_zero(self):
+        """Test samplem with zero should fail."""
+        with patch("sys.argv", ["phylo2vec", "samplem", "0"]):
+            with pytest.raises(ValueError):
+                main()
+
+    def test_big_number(self):
+        """Test samplem with a large number."""
+        with patch("sys.argv", ["phylo2vec", "samplem", f"{1000000}"]):
+            main()
+
+
+class TestFromNewick:
+    """Test the from_newick command."""
+
+    def test_valid_newick(self):
+        """Test from_newick with valid newick string."""
+        newick_str = "((0,1),2);"
+        with patch("sys.argv", ["phylo2vec", "from_newick", newick_str]):
+            args = parse_args()
+            assert hasattr(args, "newick")
+            assert args.newick == newick_str
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+                # Check that stdout == 0,2
+                assert mock_stdout.getvalue().strip() == "0,2"
+
+    def test_valid_newick2(self):
+        """Test from_newick with valid newick string."""
+        newick_str = "(((0,2)6,1)7,(3,4)5)8;"
+        with patch("sys.argv", ["phylo2vec", "from_newick", newick_str]):
+            args = parse_args()
+            assert hasattr(args, "newick")
+            assert args.newick == newick_str
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+                # Check that stdout == 0,2
+                assert mock_stdout.getvalue().strip() == "0,0,4,3"
+
+    def test_valid_newick_with_bls(self):
+        """Test from_newick with valid newick string with BLs."""
+        newick_str = "((0:0.3,1:0.1):0.5,2:0.4);"
+        with patch("sys.argv", ["phylo2vec", "from_newick", newick_str]):
+            args = parse_args()
+            assert args.newick == newick_str
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+                arr = np.genfromtxt(
+                    StringIO(mock_stdout.getvalue().strip()),
+                    delimiter=",",
+                    dtype=None,
+                )
+                assert np.array_equal(
+                    arr,
+                    np.array([[0.0, 0.3, 0.1], [2.0, 0.5, 0.4]]),
+                )
+
+    def test_empty_string(self):
+        """Test from_newick with empty string."""
+        with patch("sys.argv", ["phylo2vec", "from_newick", ""]):
+            args = parse_args()
+            assert args.newick == ""
+            main()
+
+    def test_missing_argument(self):
+        """Test from_newick without required argument."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.stderr", new_callable=StringIO):  # Suppress error output
+                with patch("sys.argv", ["phylo2vec", "from_newick"]):
+                    parse_args()
+        assert exc_info.value.code == 2
+
+
+class TestToNewick:
+    """Test the to_newick command."""
+
+    def test_valid_vector(self):
+        """Test to_newick with valid vector input."""
+        vector_input = "0,0,4,3"
+        with patch("sys.argv", ["phylo2vec", "to_newick", vector_input]):
+            args = parse_args()
+            assert hasattr(args, "vector_or_matrix")
+            assert args.vector_or_matrix == vector_input
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+                # Check that stdout == 0,2
+                assert mock_stdout.getvalue().strip() == "(((0,2)6,1)7,(3,4)5)8;"
+
+    def test_invalid_vector(self):
+        """Test to_newick with invalid vector input."""
+        with patch("sys.argv", ["phylo2vec", "to_newick", "1,2,3,4"]):
+            with pytest.raises(AssertionError):
+                main()
+
+    def test_valid_matrix(self):
+        """Test to_newick with valid matrix input."""
+        matrix_input = "0.0,1.0,2.0\n0.0,3.0,4.0"  # real newline, not literal "\n"
+        with patch("sys.argv", ["phylo2vec", "to_newick", matrix_input]):
+            args = parse_args()
+            assert hasattr(args, "vector_or_matrix")
+            assert args.vector_or_matrix == matrix_input
+            with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+                main()
+                # Check that stdout == 0,2
+                assert mock_stdout.getvalue().strip() == "((0:1,2:2)3:3,1:4)4;"
+
+    def test_missing_argument(self):
+        """Test to_newick without required argument."""
+        with pytest.raises(SystemExit) as exc_info:
+            with patch("sys.stderr", new_callable=StringIO):  # Suppress error output
+                with patch("sys.argv", ["phylo2vec", "to_newick"]):
+                    parse_args()
+        assert exc_info.value.code == 2
+
+
+if __name__ == "__main__":
+    # Run tests when file is executed directly
+    pytest.main([__file__, "-v"])

--- a/py-phylo2vec/tests/test_cli.py
+++ b/py-phylo2vec/tests/test_cli.py
@@ -1,12 +1,11 @@
-import os
-import sys
+"""Tests for the phylo2vec CLI commands."""
 
 from io import StringIO
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
-
-from unittest.mock import patch
 
 from phylo2vec.cli import parse_args, main
 

--- a/r-phylo2vec/R/extendr-wrappers.R
+++ b/r-phylo2vec/R/extendr-wrappers.R
@@ -37,11 +37,11 @@ check_v <- function(vector) invisible(.Call(wrap__check_v, vector))
 
 #' Get the cophenetic distance matrix of a Phylo2Vec matrix
 #' @export
-cophenetic_from_matrix <- function(matrix) .Call(wrap__cophenetic_from_matrix, matrix)
+cophenetic_from_matrix <- function(matrix, unrooted) .Call(wrap__cophenetic_from_matrix, matrix, unrooted)
 
 #' Get the topological cophenetic distance matrix of a Phylo2Vec vector
 #' @export
-cophenetic_from_vector <- function(vector) .Call(wrap__cophenetic_from_vector, vector)
+cophenetic_from_vector <- function(vector, unrooted) .Call(wrap__cophenetic_from_vector, vector, unrooted)
 
 #' Create an integer-taxon label mapping (label_mapping)
 #' from a string-based newick (where leaves are strings)

--- a/r-phylo2vec/R/stats.R
+++ b/r-phylo2vec/R/stats.R
@@ -6,11 +6,11 @@ library(Matrix)
 #' @param vector_or_matrix Phylo2Vec vector (ndim == 1)/matrix (ndim == 2)
 #' @return Cophenetic distance matrix
 #' @export
-cophenetic_distances <- function(vector_or_matrix) {
+cophenetic_distances <- function(vector_or_matrix, unrooted = FALSE) {
   if (is.vector(vector_or_matrix)) {
-    .Call(wrap__cophenetic_from_vector, vector_or_matrix)
+    .Call(wrap__cophenetic_from_vector, vector_or_matrix, unrooted)
   } else if (is.matrix(vector_or_matrix)) {
-    .Call(wrap__cophenetic_from_matrix, vector_or_matrix)
+    .Call(wrap__cophenetic_from_matrix, vector_or_matrix, unrooted)
   } else {
     stop("Input must be either a vector or a 2D matrix.")
   }

--- a/r-phylo2vec/man/cophenetic_from_matrix.Rd
+++ b/r-phylo2vec/man/cophenetic_from_matrix.Rd
@@ -4,7 +4,7 @@
 \alias{cophenetic_from_matrix}
 \title{Get the cophenetic distance matrix of a Phylo2Vec matrix}
 \usage{
-cophenetic_from_matrix(matrix)
+cophenetic_from_matrix(matrix, unrooted)
 }
 \description{
 Get the cophenetic distance matrix of a Phylo2Vec matrix

--- a/r-phylo2vec/man/cophenetic_from_vector.Rd
+++ b/r-phylo2vec/man/cophenetic_from_vector.Rd
@@ -4,7 +4,7 @@
 \alias{cophenetic_from_vector}
 \title{Get the topological cophenetic distance matrix of a Phylo2Vec vector}
 \usage{
-cophenetic_from_vector(vector)
+cophenetic_from_vector(vector, unrooted)
 }
 \description{
 Get the topological cophenetic distance matrix of a Phylo2Vec vector

--- a/r-phylo2vec/src/rust/src/lib.rs
+++ b/r-phylo2vec/src/rust/src/lib.rs
@@ -316,10 +316,10 @@ fn apply_label_mapping(newick: &str, label_mapping_list: Vec<String>) -> String 
 /// Get the topological cophenetic distance matrix of a Phylo2Vec vector
 /// @export
 #[extendr]
-fn cophenetic_from_vector(vector: Vec<i32>) -> RMatrix<i32> {
+fn cophenetic_from_vector(vector: Vec<i32>, unrooted: bool) -> RMatrix<i32> {
     let v_usize: Vec<usize> = as_usize(vector);
     let k = v_usize.len();
-    let coph_rs = vgraph::cophenetic_distances(&v_usize);
+    let coph_rs = vgraph::cophenetic_distances(&v_usize, unrooted);
     let mut coph_r = RMatrix::new_matrix(k + 1, k + 1, |r, c| coph_rs[[r, c]] as i32);
     let dimnames = (0..=k).map(|x| x as i32).collect::<Vec<i32>>();
     coph_r.set_dimnames(List::from_values(vec![dimnames.clone(), dimnames]));
@@ -330,8 +330,8 @@ fn cophenetic_from_vector(vector: Vec<i32>) -> RMatrix<i32> {
 /// Get the cophenetic distance matrix of a Phylo2Vec matrix
 /// @export
 #[extendr]
-fn cophenetic_from_matrix(matrix: ArrayView2<f64>) -> RMatrix<f64> {
-    let coph_rs = mgraph::cophenetic_distances(&matrix.view());
+fn cophenetic_from_matrix(matrix: ArrayView2<f64>, unrooted: bool) -> RMatrix<f64> {
+    let coph_rs = mgraph::cophenetic_distances(&matrix.view(), unrooted);
     let n_leaves = coph_rs.shape()[0];
     let mut coph_r = RMatrix::new_matrix(n_leaves, n_leaves, |r, c| coph_rs[[r, c]]);
     let dimnames = (0..n_leaves).map(|x| x as i32).collect::<Vec<i32>>();


### PR DESCRIPTION
Reinstate the "unrooted" option for cophenetic distances to match ete3. This might be useful for BME applications.

Note: comparing the "unrooted" option for phylo2vec with branch lengths requires a special kind of unrooting. ete3 simply deletes the first children that is not a leaf, while we remove the node with the largest label (which has to be a non-leaf for n_leaves > 2).