### PR TITLE
feat: re-add 'unrooted' argument to cophenetic distances

### DIFF
--- a/py-phylo2vec/phylo2vec/stats/nodewise.py
+++ b/py-phylo2vec/phylo2vec/stats/nodewise.py
@@ -23,20 +23,10 @@ def cophenetic_distances(vector_or_matrix, unrooted=False):
     numpy.ndarray
         Cophenetic distance matrix
     """
-    if unrooted:
-        warnings.warn(
-            (
-                "Argument `unrooted` is ignored. It is deprecated and "
-                "will be removed in future versions. When ensuring "
-                "compatibility with `ape` and `ete` (mode='keep'), the "
-                "argument becomes unnecessary. "
-            ),
-            FutureWarning,
-        )
     if vector_or_matrix.ndim == 2:
-        coph = core.cophenetic_distances_with_bls(vector_or_matrix)
+        coph = core.cophenetic_distances_with_bls(vector_or_matrix, unrooted=unrooted)
     elif vector_or_matrix.ndim == 1:
-        coph = core.cophenetic_distances(vector_or_matrix)
+        coph = core.cophenetic_distances(vector_or_matrix, unrooted=unrooted)
     else:
         raise ValueError(
             "vector_or_matrix should either be a vector (ndim == 1) or matrix (ndim == 2)"

--- a/py-phylo2vec/src/lib.rs
+++ b/py-phylo2vec/src/lib.rs
@@ -138,17 +138,22 @@ fn build_newick(input_pairs: Vec<(usize, usize)>) -> String {
 }
 
 #[pyfunction]
-fn cophenetic_distances(py: Python<'_>, input_vector: Vec<usize>) -> Bound<'_, PyArray2<f64>> {
-    vgraph::cophenetic_distances(&input_vector).into_pyarray(py)
+fn cophenetic_distances(
+    py: Python<'_>,
+    input_vector: Vec<usize>,
+    unrooted: bool,
+) -> Bound<'_, PyArray2<f64>> {
+    vgraph::cophenetic_distances(&input_vector, unrooted).into_pyarray(py)
 }
 
 #[pyfunction]
 fn cophenetic_distances_with_bls<'py>(
     py: Python<'py>,
     input_matrix: PyReadonlyArray2<f64>,
+    unrooted: bool,
 ) -> Bound<'py, PyArray2<f64>> {
     let m = input_matrix.as_array();
-    mgraph::cophenetic_distances(&m).into_pyarray(py)
+    mgraph::cophenetic_distances(&m, unrooted).into_pyarray(py)
 }
 
 #[pyfunction]

--- a/r-phylo2vec/R/extendr-wrappers.R
+++ b/r-phylo2vec/R/extendr-wrappers.R
@@ -37,11 +37,11 @@ check_v <- function(vector) invisible(.Call(wrap__check_v, vector))
 
 #' Get the cophenetic distance matrix of a Phylo2Vec matrix
 #' @export
-cophenetic_from_matrix <- function(matrix) .Call(wrap__cophenetic_from_matrix, matrix)
+cophenetic_from_matrix <- function(matrix, unrooted) .Call(wrap__cophenetic_from_matrix, matrix, unrooted)
 
 #' Get the topological cophenetic distance matrix of a Phylo2Vec vector
 #' @export
-cophenetic_from_vector <- function(vector) .Call(wrap__cophenetic_from_vector, vector)
+cophenetic_from_vector <- function(vector, unrooted) .Call(wrap__cophenetic_from_vector, vector, unrooted)
 
 #' Create an integer-taxon label mapping (label_mapping)
 #' from a string-based newick (where leaves are strings)

--- a/r-phylo2vec/R/stats.R
+++ b/r-phylo2vec/R/stats.R
@@ -6,11 +6,11 @@ library(Matrix)
 #' @param vector_or_matrix Phylo2Vec vector (ndim == 1)/matrix (ndim == 2)
 #' @return Cophenetic distance matrix
 #' @export
-cophenetic_distances <- function(vector_or_matrix) {
+cophenetic_distances <- function(vector_or_matrix, unrooted = FALSE) {
   if (is.vector(vector_or_matrix)) {
-    .Call(wrap__cophenetic_from_vector, vector_or_matrix)
+    .Call(wrap__cophenetic_from_vector, vector_or_matrix, unrooted)
   } else if (is.matrix(vector_or_matrix)) {
-    .Call(wrap__cophenetic_from_matrix, vector_or_matrix)
+    .Call(wrap__cophenetic_from_matrix, vector_or_matrix, unrooted)
   } else {
     stop("Input must be either a vector or a 2D matrix.")
   }

--- a/r-phylo2vec/man/cophenetic_from_matrix.Rd
+++ b/r-phylo2vec/man/cophenetic_from_matrix.Rd
@@ -4,7 +4,7 @@
 \alias{cophenetic_from_matrix}
 \title{Get the cophenetic distance matrix of a Phylo2Vec matrix}
 \usage{
-cophenetic_from_matrix(matrix)
+cophenetic_from_matrix(matrix, unrooted)
 }
 \description{
 Get the cophenetic distance matrix of a Phylo2Vec matrix

--- a/r-phylo2vec/man/cophenetic_from_vector.Rd
+++ b/r-phylo2vec/man/cophenetic_from_vector.Rd
@@ -4,7 +4,7 @@
 \alias{cophenetic_from_vector}
 \title{Get the topological cophenetic distance matrix of a Phylo2Vec vector}
 \usage{
-cophenetic_from_vector(vector)
+cophenetic_from_vector(vector, unrooted)
 }
 \description{
 Get the topological cophenetic distance matrix of a Phylo2Vec vector

--- a/r-phylo2vec/src/rust/src/lib.rs
+++ b/r-phylo2vec/src/rust/src/lib.rs
@@ -316,10 +316,10 @@ fn apply_label_mapping(newick: &str, label_mapping_list: Vec<String>) -> String 
 /// Get the topological cophenetic distance matrix of a Phylo2Vec vector
 /// @export
 #[extendr]
-fn cophenetic_from_vector(vector: Vec<i32>) -> RMatrix<i32> {
+fn cophenetic_from_vector(vector: Vec<i32>, unrooted: bool) -> RMatrix<i32> {
     let v_usize: Vec<usize> = as_usize(vector);
     let k = v_usize.len();
-    let coph_rs = vgraph::cophenetic_distances(&v_usize);
+    let coph_rs = vgraph::cophenetic_distances(&v_usize, unrooted);
     let mut coph_r = RMatrix::new_matrix(k + 1, k + 1, |r, c| coph_rs[[r, c]] as i32);
     let dimnames = (0..=k).map(|x| x as i32).collect::<Vec<i32>>();
     coph_r.set_dimnames(List::from_values(vec![dimnames.clone(), dimnames]));
@@ -330,8 +330,8 @@ fn cophenetic_from_vector(vector: Vec<i32>) -> RMatrix<i32> {
 /// Get the cophenetic distance matrix of a Phylo2Vec matrix
 /// @export
 #[extendr]
-fn cophenetic_from_matrix(matrix: ArrayView2<f64>) -> RMatrix<f64> {
-    let coph_rs = mgraph::cophenetic_distances(&matrix.view());
+fn cophenetic_from_matrix(matrix: ArrayView2<f64>, unrooted: bool) -> RMatrix<f64> {
+    let coph_rs = mgraph::cophenetic_distances(&matrix.view(), unrooted);
     let n_leaves = coph_rs.shape()[0];
     let mut coph_r = RMatrix::new_matrix(n_leaves, n_leaves, |r, c| coph_rs[[r, c]]);
     let dimnames = (0..n_leaves).map(|x| x as i32).collect::<Vec<i32>>();


### PR DESCRIPTION
Reinstate the "unrooted" option for cophenetic distances to match ete3. This might be useful for BME applications.

Note: comparing the "unrooted" option for phylo2vec with branch lengths requires a special kind of unrooting. ete3 simply deletes the first children that is not a leaf, while we remove the node with the largest label (which has to be a non-leaf for n_leaves > 2).

Supersedes #97 