### PR TITLE
chore: bump versions + cleaning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "phylo2vec"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bit-set",
  "criterion",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "r-phylo2vec"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "extendr-api",
  "ndarray",

--- a/phylo2vec/Cargo.toml
+++ b/phylo2vec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phylo2vec"
 # Rust core version
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phylo2vec"
-version = "1.3.1"
+version = "1.4.0"
 description = "Phylo2Vec"
 authors = ["Neil Scheidwasser"]
 channels = ["conda-forge"]

--- a/py-phylo2vec/phylo2vec/stats/nodewise.py
+++ b/py-phylo2vec/phylo2vec/stats/nodewise.py
@@ -1,6 +1,5 @@
 """Nodewise metrics/statistics between nodes within phylogenetic trees."""
 
-import warnings
 import numpy as np
 
 from phylo2vec import _phylo2vec_core as core

--- a/r-phylo2vec/DESCRIPTION
+++ b/r-phylo2vec/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phylo2vec
 Title: Phylo2Vec: integer vector representation of binary (phylogenetic) trees
-Version: 1.1.0
+Version: 1.2.0
 Authors@R:
     person("Neil", "Scheidwasser", "", "neil.clow@sund.ku.dk", role = c("aut", "cre"))
 Description: A tool for working with binary (phylogenetic) trees

--- a/r-phylo2vec/R/stats.R
+++ b/r-phylo2vec/R/stats.R
@@ -4,6 +4,8 @@ library(Matrix)
 #' vector (topological) or matrix (from branch lengths).
 #'
 #' @param vector_or_matrix Phylo2Vec vector (ndim == 1)/matrix (ndim == 2)
+#' @param unrooted Logical indicating whether applying the cophenetic distance
+#'  to an unrooted tree or not (see ete3). Default is FALSE.
 #' @return Cophenetic distance matrix
 #' @export
 cophenetic_distances <- function(vector_or_matrix, unrooted = FALSE) {

--- a/r-phylo2vec/man/cophenetic_distances.Rd
+++ b/r-phylo2vec/man/cophenetic_distances.Rd
@@ -5,10 +5,13 @@
 \title{Compute the cophenetic distance matrix of a Phylo2Vec
 vector (topological) or matrix (from branch lengths).}
 \usage{
-cophenetic_distances(vector_or_matrix)
+cophenetic_distances(vector_or_matrix, unrooted = FALSE)
 }
 \arguments{
 \item{vector_or_matrix}{Phylo2Vec vector (ndim == 1)/matrix (ndim == 2)}
+
+\item{unrooted}{Logical indicating whether applying the cophenetic distance
+to an unrooted tree or not (see ete3). Default is FALSE.}
 }
 \value{
 Cophenetic distance matrix

--- a/r-phylo2vec/src/rust/Cargo.toml
+++ b/r-phylo2vec/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'r-phylo2vec'
-version = '1.1.0'
+version = '1.2.0'
 edition.workspace = true
 authors.workspace = true
 description.workspace = true


### PR DESCRIPTION
R: 1.1.0 --> 1.2.0
rust: 0.4.1 --> 0.5.0
Python: 1.3.1 --> 1.4.0

Remove some unused dependencies in python's stats/nodewise and add undocumented parameter in R's cophenetic distances.