### PR TITLE
fix: fix sections in demo + typo

### DIFF
--- a/docs/demo.ipynb
+++ b/docs/demo.ipynb
@@ -320,7 +320,7 @@
    "source": [
     "##### Converting a Newick to a vector\n",
     "\n",
-    "Use ```from_newick``` to convert a vector to a Newick string."
+    "Use ```from_newick``` to convert a Newick string to a vector."
    ]
   },
   {
@@ -392,7 +392,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2.2. Edge list\n",
+    "#### 2.2.2. Edge list\n",
     "\n",
     "For a tree with $n$ leaves, we can derive a list of edges of length $2 (n-1)$\n",
     "\n",
@@ -440,7 +440,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2.3. Ancestry\n",
+    "#### 2.2.3. Ancestry\n",
     "\n",
     "A visually useful format that was derived in previous versions of Phylo2Vec is the so-called \"ancestry\" matrix.\n",
     "\n",
@@ -495,7 +495,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2.4. \"Pairs\"\n",
+    "#### 2.2.4. \"Pairs\"\n",
     "\n",
     "Another intermediate format from the Phylo2Vec/Newick conversion functions is a so-called list of pairs.\n",
     "\n",


### PR DESCRIPTION
Fix the description for "from_newick" in the demo.
Fix some indentations for subsubsections (2.2.2-2.2.4)