### PR TITLE
chore(rs): update rand to 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,12 +335,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
 ]
 
@@ -721,6 +722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "r-phylo2vec"
 version = "1.2.0"
 dependencies = [
@@ -731,20 +738,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -752,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
@@ -1015,9 +1021,21 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1183,6 +1201,12 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"

--- a/phylo2vec/src/matrix/base.rs
+++ b/phylo2vec/src/matrix/base.rs
@@ -1,6 +1,6 @@
-/// Base functions for Phylo2Vec matrices: sampling, validation, and checking properties.
+/// Base functions for `phylo2vec` matrices: sampling, validation, and checking properties.
 use ndarray::{s, Array2, ArrayView2, Axis};
-use rand::{distributions::Uniform, prelude::Distribution};
+use rand::{distr::Uniform, prelude::Distribution};
 
 use crate::vector::base::{check_v, sample_vector};
 
@@ -8,9 +8,9 @@ use crate::vector::base::{check_v, sample_vector};
 ///
 /// If ordering is True, sample an ordered tree, by default ordering is False
 ///
-/// ordering=True: v_i in {0, 1, ..., i} for i in (0, n_leaves-1)
+/// ordering=True: `v_i` in {0, 1, ..., i} for i in (0, n_leaves-1)
 ///
-/// ordering=False: v_i in {0, 1, ..., 2*i} for i in (0, n_leaves-1)
+/// ordering=False: `v_i` in {0, 1, ..., 2*i} for i in (0, n_leaves-1)
 ///
 /// # Examples
 ///
@@ -27,8 +27,8 @@ pub fn sample_matrix(n_leaves: usize, ordered: bool) -> Array2<f64> {
     // Generate the branch lengths using the uniform distribution in (0, 1)
     let mut bls = Vec::with_capacity(bl_size.0);
 
-    let mut rng = rand::thread_rng();
-    let uniform_dist = Uniform::new(0.0, 1.0); // Uniform distribution in the range (0, 1)
+    let mut rng = rand::rng();
+    let uniform_dist = Uniform::new(0.0, 1.0).unwrap(); // Uniform distribution in the range (0, 1)
 
     for _ in 0..bl_size.0 {
         let mut row = Vec::with_capacity(bl_size.1);
@@ -50,15 +50,15 @@ pub fn sample_matrix(n_leaves: usize, ordered: bool) -> Array2<f64> {
     m
 }
 
-/// Input validation of a Phylo2Vec matrix
+/// Input validation of a `phylo2vec` matrix
 ///
-/// The input is checked for the Phylo2Vec constraints on the vector part (first column)
+/// The input is checked for the `phylo2vec` constraints on the vector part (first column)
 /// and positive branch lengths in the remaining columns.
 ///
 /// # Panics
 ///
 /// Panics if:
-/// - Any element of the vector (first column of matrix) fails the Phylo2Vec constraints.
+/// - Any element of the vector (first column of matrix) fails the `phylo2vec` constraints.
 /// - Any branch length (columns 2 and 3) is not positive.
 ///
 /// # Examples

--- a/phylo2vec/src/vector/base.rs
+++ b/phylo2vec/src/vector/base.rs
@@ -1,13 +1,13 @@
-/// Base functions for Phylo2Vec vectors: sampling, validation, and checking properties.
+/// Base functions for `phylo2vec` vectors: sampling, validation, and checking properties.
 use rand::Rng;
 
 /// Sample a vector with `n_leaves` elements.
 ///
 /// If ordering is True, sample an ordered tree, by default ordering is False.
 ///
-/// ordering=True: v_i in {0, 1, ..., i} for i in (0, n_leaves-1)
+/// ordering=True: `v_i` in {0, 1, ..., i} for i in (0, n_leaves-1)
 ///
-/// ordering=False: v_i in {0, 1, ..., 2*i} for i in (0, n_leaves-1)
+/// ordering=False: `v_i` in {0, 1, ..., 2*i} for i in (0, n_leaves-1)
 ///
 /// # Examples
 ///
@@ -18,24 +18,24 @@ use rand::Rng;
 /// ```
 pub fn sample_vector(n_leaves: usize, ordered: bool) -> Vec<usize> {
     let mut v: Vec<usize> = Vec::with_capacity(n_leaves);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     if ordered {
         for i in 0..(n_leaves - 1) {
-            v.push(rng.gen_range(0..=i));
+            v.push(rng.random_range(0..=i));
         }
     } else {
         for i in 0..(n_leaves - 1) {
-            v.push(rng.gen_range(0..=2 * i));
+            v.push(rng.random_range(0..=2 * i));
         }
     }
 
     v
 }
 
-/// Input validation of a Phylo2Vec vector
+/// Input validation of a `phylo2vec` vector
 ///
-/// The input is checked to satisfy the Phylo2Vec constraints
+/// The input is checked to satisfy the `phylo2vec` constraints
 ///
 /// # Panics
 ///
@@ -49,27 +49,24 @@ pub fn sample_vector(n_leaves: usize, ordered: bool) -> Vec<usize> {
 /// ```
 pub fn check_v(v: &[usize]) {
     for (i, vi) in v.iter().enumerate() {
-        _check_max(i, *vi);
+        check_max(i, *vi);
     }
 }
 
-/// Validate the maximum value of a Phylo2Vec vector element
+/// Validate the maximum value of a `phylo2vec` vector element
 ///
 /// # Panics
-///
 /// Panics if the value is out of bounds (max = 2 * idx)
-fn _check_max(idx: usize, value: usize) {
+fn check_max(idx: usize, value: usize) {
     let absolute_max = 2 * idx;
     assert!(
         value <= absolute_max,
-        "Validation failed: v[{}] = {} is out of bounds (max = {})",
-        idx,
-        value,
-        absolute_max
+        "{}",
+        format!("Validation failed: v[{idx}] = {value} is out of bounds (max = {absolute_max})"),
     );
 }
 
-/// Check if a Phylo2Vec vector is unordered
+/// Check if a `phylo2vec` vector is unordered
 ///
 /// # Panics
 ///
@@ -94,7 +91,7 @@ fn _check_max(idx: usize, value: usize) {
 /// ```
 pub fn is_unordered(v: &[usize]) -> bool {
     for (i, vi) in v.iter().enumerate() {
-        _check_max(i, *vi);
+        check_max(i, *vi);
         if v[i] > i + 1 {
             return true;
         }


### PR DESCRIPTION
Update rand to 0.9.2, which involves the following changes from the rand API:
* Rename fn rand::thread_rng() to rand::rng() and remove from the prelude
* Rename fns Rng::gen_range to random_range, gen_bool to random_bool, gen_ratio to random_ratio