### PR TITLE
chore(r): update R CD to add OSs in release names

### DIFF
--- a/.github/workflows/cd-r.yaml
+++ b/.github/workflows/cd-r.yaml
@@ -50,7 +50,7 @@ jobs:
           Rscript -e "install.packages('rextendr', repos = c('https://extendr.r-universe.dev', 'https://cloud.r-project.org'))"
       - name: Build R package
         run: |
-          mkdir dist
+          mkdir -p dist
           Rscript -e "rextendr::document('${{ env.R_PACKAGE_DIR }}')"
           Rscript -e "devtools::build('${{ env.R_PACKAGE_DIR }}', binary = TRUE, path = 'dist')"
       - name: Upload package
@@ -60,7 +60,7 @@ jobs:
           path: dist/*.zip
       - name: Rename package for Windows
         run: |
-          mv dist/*.zip dist/phylo2vec_${{ steps.determine-version.outputs.version }}_windows.zip
+          move dist\*.zip dist\phylo2vec_${{ steps.determine-version.outputs.version }}_windows.zip
 
   build-macos:
     runs-on: ${{ matrix.platform.runner }}


### PR DESCRIPTION
Should fix #113 

Adds a renaming step so that the package is named `dist/phylo2vec_{version}_{os}.{ext}`

https://github.com/openjournals/joss-reviews/issues/9040