### PR TITLE
docs(readme): add small subsection in README for reporting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,11 @@ For comprehensive documentation, tutorials, and API reference, visit:
 ## How to Contribute (issues, feature requests...)
 
 Found a bug or want a new feature? We welcome contributions to phylo2vec! 🤗
-Feel free to report any bugs or feature requests on our [Issues page](https://github.com/sbhattlab/phylo2vec/issues).
-If you want to contribute directly to the project, fork the repository, create a new branch, and open a pull request (PR)
-on our [Pull requests page](https://github.com/sbhattlab/phylo2vec/pulls).
+Feel free to report any bugs or feature requests on our
+[Issues page](https://github.com/sbhattlab/phylo2vec/issues). If you want to
+contribute directly to the project, fork the repository, create a new branch,
+and open a pull request (PR) on our
+[Pull requests page](https://github.com/sbhattlab/phylo2vec/pulls).
 
 Please refer to our
 [Contributing guidelines](https://github.com/sbhattlab/phylo2vec/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
Add a short paragraph detailing guidelines for reporting issues or bugs directly in the README, as recommended by #111 and #120.

Fixes #120

https://github.com/openjournals/joss-reviews/issues/9040 