### PR TITLE
chore: bump versions for next release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "phylo2vec"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bit-set",
  "criterion",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "py-phylo2vec"
-version = "1.3.1"
+version = "1.5.0"
 dependencies = [
  "ndarray",
  "numpy",

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Readily downloadable datasets can be listed using:
 ```python
 from phylo2vec.datasets import list_datasets
 
-list_dataset()
+list_datasets()
 ```
 
 ## Documentation

--- a/phylo2vec/Cargo.toml
+++ b/phylo2vec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phylo2vec"
 # Rust core version
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phylo2vec"
-version = "1.4.0"
+version = "1.5.0"
 description = "Phylo2Vec"
 authors = ["Neil Scheidwasser"]
 channels = ["conda-forge"]

--- a/py-phylo2vec/Cargo.toml
+++ b/py-phylo2vec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "py-phylo2vec"
 # Python and binding version
-version = "1.3.1"
+version = "1.5.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/r-phylo2vec/DESCRIPTION
+++ b/r-phylo2vec/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phylo2vec
 Title: Phylo2Vec: integer vector representation of binary (phylogenetic) trees
-Version: 1.2.0
+Version: 1.3.0
 Authors@R:
     person("Neil", "Scheidwasser", "", "neil.clow@sund.ku.dk", role = c("aut", "cre"))
 Description: A tool for working with binary (phylogenetic) trees


### PR DESCRIPTION
Python: 1.3.1 --> 1.5.0 (forgot to bump last time)
Rust: 0.5.0 --> 0.6.0
R: 1.2.0 --> 1.3.0