### PR TITLE
feat(rs): use ryu float-to-string conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "rand",
  "regex",
  "rstest",
+ "ryu",
  "thiserror",
 ]
 

--- a/phylo2vec/Cargo.toml
+++ b/phylo2vec/Cargo.toml
@@ -12,6 +12,7 @@ bit-set = "0.8.0"
 ndarray = "0.16.1"
 rand = "*"
 regex = "1.11.1"
+ryu = "1.0"
 thiserror = "2.0.12"
 
 [dev-dependencies]

--- a/py-phylo2vec/tests/test_cli.py
+++ b/py-phylo2vec/tests/test_cli.py
@@ -264,7 +264,7 @@ class TestToNewick:
             with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
                 main()
                 # Check that stdout == 0,2
-                assert mock_stdout.getvalue().strip() == "((0:1,2:2)3:3,1:4)4;"
+                assert mock_stdout.getvalue().strip() == "((0:1.0,2:2.0)3:3.0,1:4.0)4;"
 
     def test_missing_argument(self):
         """Test to_newick without required argument."""


### PR DESCRIPTION
~10-20% upgrade in build_newick_with_bls using faster float to string conversion with Ryū.

While this is slower for floats with few decimal (e.g., 0.1) than dtoa, I think arbitrary-like floats are more common in phylo, esp. when it comes to inference.

The library is a bit stricter to convert float (so 1.0 becomes '1.0' and not '1'), so had to modify rust and python tests.