### PR TITLE
fix(rs): make remove_branch_lengts work with sci floats

### DIFF
--- a/phylo2vec/src/newick/mod.rs
+++ b/phylo2vec/src/newick/mod.rs
@@ -668,6 +668,11 @@ mod tests {
         "((0,2)5,(1,3)4)6;"
     )]
     #[case("(((2:0.02,1:0.01),0:0.041),3:1.42);", "(((2,1),0),3);")]
+    #[case("(((2:2e-2,1:1e-2),0:4.1e-2),3:1.42e0);", "(((2,1),0),3);")]
+    #[case(
+        "((0:1.94831E-06,2:9.25e-1)5:1.8209481e-3,(1:1,3:3)4:4)6;",
+        "((0,2)5,(1,3)4)6;"
+    )]
     fn test_remove_branch_lengths(#[case] newick: &str, #[case] expected: &str) {
         let result = remove_branch_lengths(newick);
         assert_eq!(result, expected);

--- a/phylo2vec/src/newick/newick_patterns.rs
+++ b/phylo2vec/src/newick/newick_patterns.rs
@@ -42,7 +42,7 @@ impl NewickPatterns {
         let pnode_pattern = r"\)(\d+)";
         let lnode_generic_pattern = r"\(\b(\w+)\b";
         let rnode_generic_pattern = r",\b(\w+)\b";
-        let bl_pattern = r":\d+(\.\d+)?";
+        let bl_pattern = r":\d+(\.\d+)?([eE][+-]?\d+)?";
         let pair_pattern = format!(r"({lnode_pattern})|({rnode_pattern})");
         Self {
             // Pattern of an integer label on the left of a pair


### PR DESCRIPTION
The Rust implementation of the BL pattern previously only recognized decimal floats. This update extends parsing to include scientific notation (e.g., 1.23e4), improving compatibility with a wider range of numeric inputs.