### PR TITLE
Edge cases graph rs

### DIFF
--- a/phylo2vec/src/vector/graph.rs
+++ b/phylo2vec/src/vector/graph.rs
@@ -26,7 +26,7 @@ pub fn _cophenetic_distances(
 
     // Special case for 1-leaf tree
     if k == 0 {
-        return array![[1.0]];
+        return array![[0.0]];
     }
 
     let bls = match bls {
@@ -559,6 +559,7 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
+    #[case(vec![], false, array![[0.0]])]
     #[case(vec![0], false, array![[0.0, 2.0], [2.0, 0.0]])]
     #[case(vec![0], true, array![[0.0, 2.0], [2.0, 0.0]])]
     #[case(vec![0, 0, 1], false, array![


### PR DESCRIPTION
For cophenetic distances: return [[0.0]]
Decide to not support k == 0 for vcov & precision, doesn't make a lot of sense given our representation