### PR TITLE
Update readme macos intel

### DIFF
--- a/.github/workflows/cd-r.yaml
+++ b/.github/workflows/cd-r.yaml
@@ -69,6 +69,8 @@ jobs:
         platform:
           - runner: macos-14
             target: arm64
+          - runner: macos-15-intel
+            target: x86_64
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci-R.yml
+++ b/.github/workflows/ci-R.yml
@@ -16,12 +16,8 @@ env:
 
 jobs:
   build_and_test:
-    name: R project - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-13]  # macos-13 is Intel x86_64
+    name: R project
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.3

--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ in Rust.
 
 ### Installing R package
 
-#### Option 1: from a release (Windows, Mac ARM64, Ubuntu >= 22.04)
+#### Option 1: from a release (Windows, Mac, Ubuntu >= 22.04)
 
-> **Note:** Pre-built Mac binaries are only available for Apple Silicon (ARM64).
-> Intel Mac users should use Option 2 or 3.
+> **Note:** Pre-built Mac binaries are available for Apple Silicon (ARM64) and
+> Intel (x86_64, macOS 15+ only). Intel Mac users on older macOS versions should
+> use Option 2 or 3.
 
 Retrieve one of the compiled binaries from the
 [releases](https://github.com/sbhattlab/phylo2vec/releases) that fits your OS.


### PR DESCRIPTION
  - Update README to specify Mac ARM64 for pre-built binaries
  - Add note directing Intel Mac users to build from source
  - Add macos-13 (Intel x86_64) to R CI matrix for build verification