### PR TITLE
fix(ci): add PyO3 generate-import-lib for Windows builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +247,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures"
@@ -674,6 +690,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
+ "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -710,6 +727,15 @@ dependencies = [
  "pyo3-build-config",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "python3-dll-a"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -923,6 +949,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"

--- a/py-phylo2vec/Cargo.toml
+++ b/py-phylo2vec/Cargo.toml
@@ -25,7 +25,8 @@ pyo3 = { version = "0.27.2", features = [
     "abi3-py312",
     "abi3-py311",
     "abi3-py310",
-    "extension-module"
+    "extension-module",
+    "generate-import-lib",
 ] }
 phylo2vec = { workspace = true }
 numpy = "0.27.0"


### PR DESCRIPTION
## Summary
- Adds `generate-import-lib` feature to PyO3 in `py-phylo2vec/Cargo.toml`
- This generates the Windows import library at build time without needing a Python interpreter, fixing the `CD Python` Windows CI failure caused by `maturin-action` encountering the WindowsApps `python3.exe` alias (`EACCES` permission error)

## Test plan
- [x] Verify `CD Python` workflow passes on Windows (`x64` and `x86`)
- [x] Verify Linux and macOS builds are unaffected