### PR TITLE
ci(r): skip Suggests in CD R builds

### DIFF
--- a/.github/workflows/cd-r.yaml
+++ b/.github/workflows/cd-r.yaml
@@ -43,6 +43,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: ${{ env.R_PACKAGE_DIR }}
+          dependencies: '"hard"'
           extra-packages: |
             any::devtools
       - name: Install rextendr
@@ -92,6 +93,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: ${{ env.R_PACKAGE_DIR }}
+          dependencies: '"hard"'
           extra-packages: |
             any::devtools
       - name: Install rextendr
@@ -137,6 +139,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: ${{ env.R_PACKAGE_DIR }}
+          dependencies: '"hard"'
           extra-packages: |
             any::devtools
       - name: Install rextendr


### PR DESCRIPTION
## Summary

- CD R builds were failing because `TreeDist 2.12.0` fails to link from source under R 4.6.0 / Ubuntu 22.04 / gcc 11 (upstream linker error: `relocation truncated to fit … against .bss`).
- TreeDist is only in `Suggests` (alongside `testthat`, `ape`) and is used solely for tests. The CD jobs run `rextendr::document()` + `devtools::build(binary = TRUE)` — no tests, examples, or vignettes — so Suggests aren't needed to produce the binary artifact.
- Pass `dependencies: '"hard"'` to `setup-r-dependencies` in all three CD build jobs so it installs only `Depends`/`Imports`/`LinkingTo` and skips Suggests.

Note: CI-R is unaffected because it uses pixi, not `setup-r-dependencies`, and it does still run tests against TreeDist.

## Test plan

- [ ] CD R workflow (`build-windows`, `build-macos`, `build-linux`) all succeed on this branch
- [ ] Built binaries still load and `sample_vector(5, FALSE)` works (covered by `test-release` job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)